### PR TITLE
ADD: MultiPlay画面遷移設定 #111

### DIFF
--- a/api/pong/consumers.py
+++ b/api/pong/consumers.py
@@ -125,12 +125,32 @@ class GameConsumer(AsyncWebsocketConsumer):
 
         print(f"Player {self.username} disconnected from game {self.session_id}")
 
-        await self.channel_layer.group_discard(self.game_group_name, self.channel_name)
-
+        # ゲームが存在する場合、切断による敗北処理を実行
         if self.session_id in self.games:
             game = self.games[self.session_id]
+            game.handle_disconnection(self.username)
+            
+            # 残ったプレイヤーに切断を通知
+            await self.channel_layer.group_send(
+                self.game_group_name,
+                {
+                    "type": "player_disconnected",
+                    "disconnected_player": self.username
+                }
+            )
+            
+            # ゲーム状態を保存して終了
             await self.save_game_state(game)
             del self.games[self.session_id]
+
+        await self.channel_layer.group_discard(self.game_group_name, self.channel_name)
+
+    async def player_disconnected(self, event):
+        """切断通知をクライアントに送信"""
+        await self.send(text_data=json.dumps({
+            "type": "player_disconnected",
+            "disconnected_player": event["disconnected_player"]
+        }))
 
     @database_sync_to_async
     def save_game_state(self, game):

--- a/api/pong/consumers.py
+++ b/api/pong/consumers.py
@@ -129,16 +129,13 @@ class GameConsumer(AsyncWebsocketConsumer):
         if self.session_id in self.games:
             game = self.games[self.session_id]
             game.handle_disconnection(self.username)
-            
+
             # 残ったプレイヤーに切断を通知
             await self.channel_layer.group_send(
                 self.game_group_name,
-                {
-                    "type": "player_disconnected",
-                    "disconnected_player": self.username
-                }
+                {"type": "player_disconnected", "disconnected_player": self.username},
             )
-            
+
             # ゲーム状態を保存して終了
             await self.save_game_state(game)
             del self.games[self.session_id]
@@ -147,10 +144,14 @@ class GameConsumer(AsyncWebsocketConsumer):
 
     async def player_disconnected(self, event):
         """切断通知をクライアントに送信"""
-        await self.send(text_data=json.dumps({
-            "type": "player_disconnected",
-            "disconnected_player": event["disconnected_player"]
-        }))
+        await self.send(
+            text_data=json.dumps(
+                {
+                    "type": "player_disconnected",
+                    "disconnected_player": event["disconnected_player"],
+                }
+            )
+        )
 
     @database_sync_to_async
     def save_game_state(self, game):

--- a/api/pong/game_logic.py
+++ b/api/pong/game_logic.py
@@ -163,9 +163,15 @@ class MultiplayerPongGame:
             disconnected_player (str): 切断したプレイヤーのユーザー名
         """
         # 残ったプレイヤーの勝利が確定するようにスコアを設定
-        winning_player = self.player2_name if disconnected_player == self.player1_name else self.player1_name
+        winning_player = (
+            self.player2_name
+            if disconnected_player == self.player1_name
+            else self.player1_name
+        )
         self.score[winning_player] = self.WINNING_SCORE
-        self.score[disconnected_player] = min(self.score[disconnected_player], self.WINNING_SCORE - 1)
+        self.score[disconnected_player] = min(
+            self.score[disconnected_player], self.WINNING_SCORE - 1
+        )
 
         # ゲームを終了状態に
         self.is_active = False

--- a/api/pong/game_logic.py
+++ b/api/pong/game_logic.py
@@ -156,6 +156,20 @@ class MultiplayerPongGame:
             return self.player2_name
         return None
 
+    def handle_disconnection(self, disconnected_player: str) -> None:
+        """
+        プレイヤーの切断時の処理
+        Args:
+            disconnected_player (str): 切断したプレイヤーのユーザー名
+        """
+        # 残ったプレイヤーの勝利が確定するようにスコアを設定
+        winning_player = self.player2_name if disconnected_player == self.player1_name else self.player1_name
+        self.score[winning_player] = self.WINNING_SCORE
+        self.score[disconnected_player] = min(self.score[disconnected_player], self.WINNING_SCORE - 1)
+
+        # ゲームを終了状態に
+        self.is_active = False
+
     # 以下、プライベートメソッド
     def _handle_wall_collision(self) -> None:
         if abs(self.ball.x) > self.FIELD_WIDTH / 2:

--- a/frontend/src/pages/MultiPlay/Game/index.ts
+++ b/frontend/src/pages/MultiPlay/Game/index.ts
@@ -49,36 +49,37 @@ const GamePage = new Page({
       wsConnected = true;
     };
 
-    socket.onmessage = (event) => {
+    socket.onmessage = async (event) => {  // async を追加
       try {
         const data = JSON.parse(event.data);
         if (data.type === 'state_update') {
           renderer.updateState(data.state);
           updateScoreBoard(data.state.score);
           
-          // ここから追加する処理
-          if (data.state.game_over) {
-            // セッションIDからプレイヤー名を取得
-            const [player1Name, player2Name] = sessionId?.replace('game_', '').split('_') || [];
-            const opponent = username === player1Name ? player2Name : player1Name;
+          if (!data.state.is_active) {
+            // 確実にデータを処理するため、Promise を使用
+            await new Promise<void>(resolve => {
+              const [player1Name, player2Name] = sessionId?.replace('game_', '').split('_') || [];
+              const opponent = username === player1Name ? player2Name : player1Name;
     
-            const finalScore = {
-              player1: data.state.score[username],
-              player2: data.state.score[opponent],
-              opponent: opponent  // 対戦相手の名前を保存
-            };
-            
-            localStorage.setItem('finalScore', JSON.stringify(finalScore));
-            localStorage.setItem('gameMode', 'multiplayer');
-            
-            // リザルト画面への遷移
-            setTimeout(() => {
-              window.location.href = '/result';
-            }, 1000);
+              const finalScore = {
+                player1: data.state.score[username],
+                player2: data.state.score[opponent],
+                opponent: opponent
+              };
+              
+              localStorage.setItem('finalScore', JSON.stringify(finalScore));
+              localStorage.setItem('gameMode', 'multiplayer');
+              
+              setTimeout(() => {
+                resolve();
+                window.location.href = '/result';
+              }, 1000);
+            });
           }
         }
       } catch (e) {
-        console.error('Error processing game message:', e);
+        console.error('Error in WebSocket message handler:', e);
       }
     };
 

--- a/frontend/src/pages/MultiPlay/Game/index.ts
+++ b/frontend/src/pages/MultiPlay/Game/index.ts
@@ -55,6 +55,27 @@ const GamePage = new Page({
         if (data.type === 'state_update') {
           renderer.updateState(data.state);
           updateScoreBoard(data.state.score);
+          
+          // ここから追加する処理
+          if (data.state.game_over) {
+            // セッションIDからプレイヤー名を取得
+            const [player1Name, player2Name] = sessionId?.replace('game_', '').split('_') || [];
+            const opponent = username === player1Name ? player2Name : player1Name;
+    
+            const finalScore = {
+              player1: data.state.score[username],
+              player2: data.state.score[opponent],
+              opponent: opponent  // 対戦相手の名前を保存
+            };
+            
+            localStorage.setItem('finalScore', JSON.stringify(finalScore));
+            localStorage.setItem('gameMode', 'multiplayer');
+            
+            // リザルト画面への遷移
+            setTimeout(() => {
+              window.location.href = '/result';
+            }, 1000);
+          }
         }
       } catch (e) {
         console.error('Error processing game message:', e);

--- a/frontend/src/pages/MultiPlay/Game/index.ts
+++ b/frontend/src/pages/MultiPlay/Game/index.ts
@@ -77,6 +77,30 @@ const GamePage = new Page({
               }, 1000);
             });
           }
+        } else if (data.type === 'player_disconnected') {
+          // 相手の切断を検知したら少し待ってからリザルト画面に遷移
+          await new Promise<void>(resolve => {
+            const [player1Name, player2Name] = sessionId?.replace('game_', '').split('_') || [];
+            const opponent = username === player1Name ? player2Name : player1Name;
+            
+            // 切断情報を含めた最終スコアを保存
+            const finalScore = {
+              player1: data.state?.score?.[username] ?? 15, // 切断時は残ったプレイヤーが15点
+              player2: data.state?.score?.[opponent] ?? 0,
+              opponent: opponent,
+              disconnected: true, // 切断による終了を示すフラグ
+              disconnectedPlayer: data.disconnected_player
+            };
+            
+            localStorage.setItem('finalScore', JSON.stringify(finalScore));
+            localStorage.setItem('gameMode', 'multiplayer');
+            
+            // 少し待ってからリザルト画面に遷移
+            setTimeout(() => {
+              resolve();
+              window.location.href = '/result';
+            }, 1000);
+          });
         }
       } catch (e) {
         console.error('Error in WebSocket message handler:', e);
@@ -91,6 +115,24 @@ const GamePage = new Page({
     socket.onclose = () => {
       console.log('Game WebSocket closed');
       wsConnected = false;
+    
+      // 自分が切断された場合（ネットワークエラーなど）の処理
+      const [player1Name, player2Name] = sessionId?.replace('game_', '').split('_') || [];
+      const opponent = username === player1Name ? player2Name : player1Name;
+      
+      const finalScore = {
+        player1: 0,  // 切断したプレイヤーは敗北
+        player2: 15, // 相手が勝利
+        opponent: opponent,
+        disconnected: true,
+        disconnectedPlayer: username // 自分が切断したプレイヤー
+      };
+      
+      localStorage.setItem('finalScore', JSON.stringify(finalScore));
+      localStorage.setItem('gameMode', 'multiplayer');
+      
+      // リザルト画面に遷移
+      window.location.href = '/result';
     };
 
     // キー入力の状態管理

--- a/frontend/src/pages/MultiPlay/Waiting/index.ts
+++ b/frontend/src/pages/MultiPlay/Waiting/index.ts
@@ -18,6 +18,17 @@ const WaitingPage = new Page({
     const statusElement = document.getElementById('connection-status');
     const cancelButton = document.getElementById('cancel-button');
 
+    // WebSocketの切断と遷移を行う関数
+    const handleNavigation = () => {
+      if (socket) {
+        socket.close();
+        socket = null;
+      }
+    };
+
+    // ブラウザの戻る/進むボタン対応
+    window.addEventListener('popstate', handleNavigation);
+
     function initWebSocket() {
       console.log('Initializing WebSocket...');
       socket = new WebSocket(`${WS_URL}/ws/matchmaking/`);
@@ -82,9 +93,7 @@ const WaitingPage = new Page({
     // キャンセルボタンのイベントリスナー
     if (cancelButton) {
       cancelButton.addEventListener('click', () => {
-        if (socket) {
-          socket.close();
-        }
+        handleNavigation();
         window.location.href = '/multiplay';
       });
     }
@@ -94,10 +103,8 @@ const WaitingPage = new Page({
 
     // クリーンアップ
     return () => {
-      if (socket) {
-        socket.close();
-        socket = null;
-      }
+      handleNavigation();
+      window.removeEventListener('popstate', handleNavigation);
     };
   },
 });

--- a/frontend/src/pages/Result/index.ts
+++ b/frontend/src/pages/Result/index.ts
@@ -60,42 +60,43 @@ const ResultPage = new Page({
   },
   mounted: async () => {
     const storedScore = localStorage.getItem('finalScore');
-    const difficulty = localStorage.getItem('selectedLevel');
+    const gameMode = localStorage.getItem('gameMode');
     const username = localStorage.getItem('username');
 
-    if (storedScore && difficulty) {
+    if (storedScore && gameMode === 'multiplayer') {
       const score = JSON.parse(storedScore);
 
       // スコアの表示を更新
       const playerScoreElement = document.getElementById('playerScore');
-      const cpuScoreElement = document.getElementById('cpuScore');
+      const opponentScoreElement = document.getElementById('cpuScore');
       const resultMessage = document.getElementById('result-message');
       const playerNameElement = document.getElementById('playerName');
+      const opponentNameElement = document.querySelector('.cpu-side .player-name');
 
-      // プレイヤー名の表示を更新
       if (playerNameElement && username) {
         playerNameElement.textContent = username;
       }
 
-      if (playerScoreElement) playerScoreElement.textContent = String(score.player1);
-      if (cpuScoreElement) cpuScoreElement.textContent = String(score.player2);
+      if (opponentNameElement && score.opponent) {
+        opponentNameElement.textContent = score.opponent;
+      }
 
-      // 勝敗メッセージの設定
+      if (playerScoreElement) playerScoreElement.textContent = String(score.player1);
+      if (opponentScoreElement) opponentScoreElement.textContent = String(score.player2);
+
       if (resultMessage) {
         if (score.player1 > score.player2) {
           resultMessage.textContent = 'You Win!';
           resultMessage.className = 'result-message win';
         } else {
-          resultMessage.textContent = 'CPU Wins!';
+          resultMessage.textContent = 'Opponent Wins!';
           resultMessage.className = 'result-message lose';
         }
       }
 
-      // 結果をバックエンドに送信
-      await sendGameResult(score);
-
-      // スコアをクリア
+      // ストレージのクリア
       localStorage.removeItem('finalScore');
+      localStorage.removeItem('gameMode');
     }
 
     const exitBtn = document.getElementById('exitBtn');


### PR DESCRIPTION
## 概要
マルチプレイ関連の画面遷移をすべて設定する

## 変更点

- [x] 途中切断があった場合、即座にリザルトへ
- [ ] ~~終了済マッチにURLなどで直接アクセスしても「終了済」でmode選択画面へのボタンがあるだけに~~
- [x] waiting画面から戻るボタンの有効化
- [x] ゲーム終了時にリザルト画面への有効化(リザルトから前画面には戻れない)

## 影響範囲

このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。

## テスト
- [x] どちらかのプレイヤーが15点を取得した場合に対戦終了時にリザルト画面に遷移する
- [x] マッチのウェイティング画面からブラウザの戻るボタンが有効である
- [x] 片方のプレイヤーが途中切断した場合、残ったプレイヤーはリザルト画面に遷移して勝利となる
- [ ] ~~終了済マッチにアクセスしてもプレイ出来ずにマッチ待機画面に遷移する~~

## 関連Issue
- 関連Issue: #111 
