### PR TITLE
INVALID: Tournament機能実装 : frontend #157

### DIFF
--- a/api/pong/serializers.py
+++ b/api/pong/serializers.py
@@ -195,6 +195,14 @@ class TournamentGameSessionSerializer(serializers.ModelSerializer):
             "started_at",
             "completed_at",
             "current_round",
+            "participants"
+        ]
+
+    def get_participants(self, obj):
+        """参加者のユーザー名リストを取得"""
+        return [
+            participant.user.username 
+            for participant in obj.tournamentparticipant_set.all()
         ]
 
     def validate(self, data):

--- a/api/pong/tournament/handlers.py
+++ b/api/pong/tournament/handlers.py
@@ -28,12 +28,6 @@ class TournamentWebSocketHandler(AsyncWebsocketConsumer):
         self.username = self.scope["url_route"]["kwargs"]["username"]
         self.tournament_group = f"tournament_{self.tournament_id}"
 
-        # トーナメントの初期化
-        service = self.get_service()
-        if not await service.initialize_tournament(self.tournament_id):
-            await self.close()
-            return
-
         # グループへの参加
         await self.channel_layer.group_add(self.tournament_group, self.channel_name)
         await self.accept()

--- a/api/pong/tournament/repositories.py
+++ b/api/pong/tournament/repositories.py
@@ -9,7 +9,6 @@ from ..models import (
     User,
 )
 
-
 class TournamentRepository:
     """トーナメントに関連するデータベース操作を抽象化するリポジトリクラス"""
 

--- a/api/pong/tournament/services.py
+++ b/api/pong/tournament/services.py
@@ -53,8 +53,6 @@ class TournamentService:
 
             # 参加者の追加（データベース）
             logger.info(f"Adding participant to repository: {username}")
-            # TODO: 以下の取得に失敗している
-            # NOTE: async_to_syncではなかった
             participant = await TournamentRepository.add_participant(tournament_id, username)
             logger.info(f"Repository add_participant result: {participant}")
             

--- a/api/pong/tournament/services.py
+++ b/api/pong/tournament/services.py
@@ -53,7 +53,8 @@ class TournamentService:
 
             # 参加者の追加（データベース）
             logger.info(f"Adding participant to repository: {username}")
-            # TODO: ここasync_to_syncかも???
+            # TODO: 以下の取得に失敗している
+            # NOTE: async_to_syncではなかった
             participant = await TournamentRepository.add_participant(tournament_id, username)
             logger.info(f"Repository add_participant result: {participant}")
             

--- a/api/pong/urls.py
+++ b/api/pong/urls.py
@@ -12,6 +12,8 @@ from .views import (
     UserAvatarUpdateView,
     UserListCreateView,
     UserRetrieveUpdateView,
+    TournamentListCreateView,
+    tournament_status,
 )
 
 app_name = "pong"
@@ -51,5 +53,7 @@ urlpatterns = [
         "games/<int:pk>/", GameRetrieveUpdateDestroyView.as_view(), name="game-detail"
     ),
     # Tournament
-    # TODO: add Tournament frontend
+    path("tournaments/", TournamentListCreateView.as_view(), name="tournament-list-create"),
+    path("tournaments/<int:tournament_id>/status/", tournament_status, name="tournament-status"),
+
 ]

--- a/api/pong/urls.py
+++ b/api/pong/urls.py
@@ -15,6 +15,7 @@ from .views import (
     TournamentListCreateView,
     tournament_status,
 )
+from . import views
 
 app_name = "pong"
 urlpatterns = [
@@ -55,5 +56,5 @@ urlpatterns = [
     # Tournament
     path("tournaments/", TournamentListCreateView.as_view(), name="tournament-list-create"),
     path("tournaments/<int:tournament_id>/status/", tournament_status, name="tournament-status"),
-
+    path('tournaments/<int:tournament_id>/join/', views.join_tournament),
 ]

--- a/api/pong/views.py
+++ b/api/pong/views.py
@@ -18,7 +18,9 @@ from .serializers import (
 )
 from .tournament.repositories import TournamentRepository
 from .tournament.services import TournamentService
-from asgiref.sync import sync_to_async
+from asgiref.sync import async_to_sync
+import logging
+logger = logging.getLogger(__name__)
 
 class HealthCheckView(APIView):
     permission_classes = [AllowAny]
@@ -281,13 +283,12 @@ class TournamentListCreateView(generics.ListCreateAPIView):
 
         return queryset[:limit]
 
-    def perform_create(self, serializer):  # asyncを削除
-       """トーナメントを作成"""
-       tournament = serializer.save()  # awaitを削除
-       # 非同期処理を同期的に扱う
-       service = TournamentService()
-       sync_to_async(service.initialize_tournament)(tournament.id)
-       return tournament
+    def perform_create(self, serializer):
+        tournament = serializer.save()
+        service = TournamentService()
+        # 非同期関数を同期的に実行
+        async_to_sync(service.initialize_tournament)(tournament.id)
+        return tournament
 
 
 @api_view(["GET"])

--- a/api/pong/views.py
+++ b/api/pong/views.py
@@ -280,9 +280,12 @@ class TournamentListCreateView(generics.ListCreateAPIView):
             queryset = queryset.filter(status=status)
 
         return queryset[:limit]
+
     async def perform_create(self, serializer):
         """トーナメントを作成"""
+        # print("Received tournament creation request")
         tournament = await serializer.save()
+        # print("Created tournament object:", vars(tournament))
         # サービスの初期化
         service = TournamentService()
         await service.initialize_tournament(tournament.id)

--- a/api/pong/views.py
+++ b/api/pong/views.py
@@ -18,7 +18,7 @@ from .serializers import (
 )
 from .tournament.repositories import TournamentRepository
 from .tournament.services import TournamentService
-import asyncio
+from asgiref.sync import sync_to_async
 
 class HealthCheckView(APIView):
     permission_classes = [AllowAny]
@@ -286,7 +286,7 @@ class TournamentListCreateView(generics.ListCreateAPIView):
        tournament = serializer.save()  # awaitを削除
        # 非同期処理を同期的に扱う
        service = TournamentService()
-       asyncio.create_task(service.initialize_tournament(tournament.id))
+       sync_to_async(service.initialize_tournament)(tournament.id)
        return tournament
 
 

--- a/api/pong/views.py
+++ b/api/pong/views.py
@@ -283,9 +283,7 @@ class TournamentListCreateView(generics.ListCreateAPIView):
 
     async def perform_create(self, serializer):
         """トーナメントを作成"""
-        # print("Received tournament creation request")
         tournament = await serializer.save()
-        # print("Created tournament object:", vars(tournament))
         # サービスの初期化
         service = TournamentService()
         await service.initialize_tournament(tournament.id)

--- a/api/pong/views.py
+++ b/api/pong/views.py
@@ -18,7 +18,7 @@ from .serializers import (
 )
 from .tournament.repositories import TournamentRepository
 from .tournament.services import TournamentService
-
+import asyncio
 
 class HealthCheckView(APIView):
     permission_classes = [AllowAny]
@@ -281,13 +281,13 @@ class TournamentListCreateView(generics.ListCreateAPIView):
 
         return queryset[:limit]
 
-    async def perform_create(self, serializer):
-        """トーナメントを作成"""
-        tournament = await serializer.save()
-        # サービスの初期化
-        service = TournamentService()
-        await service.initialize_tournament(tournament.id)
-        return tournament
+    def perform_create(self, serializer):  # asyncを削除
+       """トーナメントを作成"""
+       tournament = serializer.save()  # awaitを削除
+       # 非同期処理を同期的に扱う
+       service = TournamentService()
+       asyncio.create_task(service.initialize_tournament(tournament.id))
+       return tournament
 
 
 @api_view(["GET"])

--- a/frontend/src/core/EventEmitter.ts
+++ b/frontend/src/core/EventEmitter.ts
@@ -1,0 +1,86 @@
+// frontend/src/core/EventEmitter.ts
+// NOTE: イベント管理機能を持つ基底クラス
+type EventHandler = (...args: any[]) => void;
+
+export class EventEmitter {
+  private listeners: Map<string, Set<EventHandler>>;
+
+  constructor() {
+    this.listeners = new Map();
+  }
+
+  /**
+   * イベントリスナーを登録
+   * @param event イベント名
+   * @param handler イベントハンドラ
+   */
+  public on(event: string, handler: EventHandler): void {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event)!.add(handler);
+  }
+
+  /**
+   * イベントリスナーを削除
+   * @param event イベント名
+   * @param handler イベントハンドラ
+   */
+  public off(event: string, handler: EventHandler): void {
+    if (!this.listeners.has(event)) return;
+    this.listeners.get(event)!.delete(handler);
+    if (this.listeners.get(event)!.size === 0) {
+      this.listeners.delete(event);
+    }
+  }
+
+  /**
+   * イベントの発火
+   * @param event イベント名
+   * @param args イベントハンドラに渡す引数
+   */
+  public emit(event: string, ...args: any[]): void {
+    if (!this.listeners.has(event)) return;
+    this.listeners.get(event)!.forEach(handler => {
+      try {
+        handler(...args);
+      } catch (error) {
+        console.error(`Error in event handler for ${event}:`, error);
+      }
+    });
+  }
+
+  /**
+   * 1回だけ実行されるイベントリスナーを登録
+   * @param event イベント名
+   * @param handler イベントハンドラ
+   */
+  public once(event: string, handler: EventHandler): void {
+    const wrapper = (...args: any[]) => {
+      this.off(event, wrapper);
+      handler(...args);
+    };
+    this.on(event, wrapper);
+  }
+
+  /**
+   * 特定のイベントのすべてのリスナーを削除
+   * @param event イベント名
+   */
+  public removeAllListeners(event?: string): void {
+    if (event) {
+      this.listeners.delete(event);
+    } else {
+      this.listeners.clear();
+    }
+  }
+
+  /**
+   * 登録されているリスナーの数を取得
+   * @param event イベント名
+   * @returns リスナーの数
+   */
+  public listenerCount(event: string): number {
+    return this.listeners.has(event) ? this.listeners.get(event)!.size : 0;
+  }
+}

--- a/frontend/src/core/WebSocketManager.ts
+++ b/frontend/src/core/WebSocketManager.ts
@@ -1,0 +1,127 @@
+// frontend/src/core/WebSocketManager.ts
+
+import { EventEmitter } from './EventEmitter';
+import { Logger } from './Logger';
+
+export interface WebSocketMessage {
+  type: string;
+  [key: string]: any;
+}
+
+export class WebSocketManager extends EventEmitter {
+  private socket: WebSocket | null = null;
+  private logger: Logger;
+  private reconnectAttempts = 0;
+  private readonly MAX_RECONNECT_ATTEMPTS = 3;
+
+  constructor() {
+    super();
+    this.logger = new Logger();
+  }
+
+  /**
+   * WebSocket接続を確立
+   * @param url WebSocketのURL
+   */
+  public connect(url: string): void {
+    try {
+      this.socket = new WebSocket(url);
+      this.setupEventHandlers();
+    } catch (error) {
+      this.logger.error('Failed to create WebSocket connection:', error);
+      this.emit('error', 'Failed to create connection');
+    }
+  }
+
+  /**
+   * WebSocket接続を切断
+   */
+  public disconnect(): void {
+    if (this.socket) {
+      this.socket.close();
+      this.socket = null;
+      this.reconnectAttempts = 0;
+    }
+  }
+
+  /**
+   * メッセージを送信
+   * @param message 送信するメッセージ
+   */
+  public send(message: WebSocketMessage): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+      this.logger.error('WebSocket is not connected');
+      this.emit('error', 'WebSocket is not connected');
+      return;
+    }
+
+    try {
+      this.socket.send(JSON.stringify(message));
+    } catch (error) {
+      this.logger.error('Failed to send message:', error);
+      this.emit('error', 'Failed to send message');
+    }
+  }
+
+  /**
+   * 接続状態を取得
+   */
+  public isConnected(): boolean {
+    return this.socket !== null && this.socket.readyState === WebSocket.OPEN;
+  }
+
+  /**
+   * WebSocketのイベントハンドラを設定
+   */
+  private setupEventHandlers(): void {
+    if (!this.socket) return;
+
+    this.socket.onopen = () => {
+      this.logger.info('WebSocket connected');
+      this.reconnectAttempts = 0;
+      this.emit('connected');
+    };
+
+    this.socket.onclose = () => {
+      this.logger.info('WebSocket disconnected');
+      this.emit('disconnected');
+      this.handleReconnect();
+    };
+
+    this.socket.onerror = (error) => {
+      this.logger.error('WebSocket error:', error);
+      this.emit('error', 'Connection error occurred');
+    };
+
+    this.socket.onmessage = (event) => {
+      try {
+        const message = JSON.parse(event.data) as WebSocketMessage;
+        this.emit(message.type, message);
+      } catch (error) {
+        this.logger.error('Failed to parse message:', error);
+        this.emit('error', 'Failed to parse message');
+      }
+    };
+  }
+
+  /**
+   * 再接続を試みる
+   */
+  private handleReconnect(): void {
+    if (this.reconnectAttempts >= this.MAX_RECONNECT_ATTEMPTS) {
+      this.logger.error('Max reconnection attempts reached');
+      this.emit('error', 'Failed to reconnect');
+      return;
+    }
+
+    this.reconnectAttempts++;
+    this.logger.info(`Attempting to reconnect (${this.reconnectAttempts}/${this.MAX_RECONNECT_ATTEMPTS})`);
+    
+    // 再接続試行の前に少し待機
+    setTimeout(() => {
+      if (this.socket?.url) {
+        this.connect(this.socket.url);
+      }
+    }, 1000 * this.reconnectAttempts); // 試行回数に応じて待機時間を増やす
+  }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -15,6 +15,7 @@ import FriendsPage from './pages/Friends/index';
 import LogoutPage from './pages/Logout';
 import ResultPage from './pages/Result/index';
 import SettingsUserPage from './pages/Settings/User/index';
+import TournamentPage from '@/pages/Tournament/index';
 
 import { Page } from './core/Page';
 
@@ -39,7 +40,7 @@ const routes: Record<string, Page> = {
   '/multiplay/game': GamePage,
   // '/games/:id/results': GameResultsPage,
   '/result': ResultPage,
-  // '/tournament': TournamentPage,
+  '/tournament': TournamentPage,
   // '/tournament/:id': TournamentPage,
   '/leaderboard': LeaderboardPage,
   '/friends': FriendsPage,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -17,6 +17,7 @@ import ResultPage from './pages/Result/index';
 import SettingsUserPage from './pages/Settings/User/index';
 import TournamentListPage from '@/pages/Tournament/List/index';
 import TournamentWaitingPage from '@/pages/Tournament/Waiting/index';
+import TournamentGamePage from '@/pages/Tournament/Game/index';
 
 import { Page } from './core/Page';
 
@@ -43,6 +44,7 @@ const routes: Record<string, Page> = {
   '/result': ResultPage,
   '/tournament': TournamentListPage,
   '/tournament/waiting': TournamentWaitingPage,
+  '/tournament/game': TournamentGamePage,
   // '/tournament/:id': TournamentPage,
   '/leaderboard': LeaderboardPage,
   '/friends': FriendsPage,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -15,7 +15,8 @@ import FriendsPage from './pages/Friends/index';
 import LogoutPage from './pages/Logout';
 import ResultPage from './pages/Result/index';
 import SettingsUserPage from './pages/Settings/User/index';
-import TournamentPage from '@/pages/Tournament/index';
+import TournamentListPage from '@/pages/Tournament/List/index';
+import TournamentWaitingPage from '@/pages/Tournament/Waiting/index';
 
 import { Page } from './core/Page';
 
@@ -40,7 +41,8 @@ const routes: Record<string, Page> = {
   '/multiplay/game': GamePage,
   // '/games/:id/results': GameResultsPage,
   '/result': ResultPage,
-  '/tournament': TournamentPage,
+  '/tournament': TournamentListPage,
+  '/tournament/waiting': TournamentWaitingPage,
   // '/tournament/:id': TournamentPage,
   '/leaderboard': LeaderboardPage,
   '/friends': FriendsPage,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -19,6 +19,7 @@ import TournamentListPage from '@/pages/Tournament/List/index';
 import TournamentWaitingPage from '@/pages/Tournament/Waiting/index';
 import TournamentGamePage from '@/pages/Tournament/Game/index';
 import TournamentBracketPage from '@/pages/Tournament/Bracket/index';
+import TournamentResultPage from '@/pages/Tournament/Result/index';
 
 import { Page } from './core/Page';
 
@@ -47,6 +48,7 @@ const routes: Record<string, Page> = {
   '/tournament/waiting': TournamentWaitingPage,
   '/tournament/game': TournamentGamePage,
   '/tournament/bracket': TournamentBracketPage,
+  '/tournament/result': TournamentResultPage,
   // '/tournament/:id': TournamentPage,
   '/leaderboard': LeaderboardPage,
   '/friends': FriendsPage,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -18,6 +18,7 @@ import SettingsUserPage from './pages/Settings/User/index';
 import TournamentListPage from '@/pages/Tournament/List/index';
 import TournamentWaitingPage from '@/pages/Tournament/Waiting/index';
 import TournamentGamePage from '@/pages/Tournament/Game/index';
+import TournamentBracketPage from '@/pages/Tournament/Bracket/index';
 
 import { Page } from './core/Page';
 
@@ -45,6 +46,7 @@ const routes: Record<string, Page> = {
   '/tournament': TournamentListPage,
   '/tournament/waiting': TournamentWaitingPage,
   '/tournament/game': TournamentGamePage,
+  '/tournament/bracket': TournamentBracketPage,
   // '/tournament/:id': TournamentPage,
   '/leaderboard': LeaderboardPage,
   '/friends': FriendsPage,

--- a/frontend/src/pages/Tournament/Bracket/index.html
+++ b/frontend/src/pages/Tournament/Bracket/index.html
@@ -1,0 +1,23 @@
+<!-- frontend/src/pages/Tournament/Bracket/index.html -->
+<div class="tournament-bracket-container">
+  <div class="tournament-header">
+    <h1>Tournament Bracket</h1>
+    <div id="error-container"></div>
+  </div>
+
+  <div class="bracket">
+    <div class="round semifinals">
+      <h2>Semifinals</h2>
+      <div class="matches" id="semifinals">
+        <!-- 準決勝の試合が動的に追加される -->
+      </div>
+    </div>
+
+    <div class="round finals">
+      <h2>Finals</h2>
+      <div class="matches" id="finals">
+        <!-- 決勝の試合が動的に追加される -->
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/pages/Tournament/Bracket/index.ts
+++ b/frontend/src/pages/Tournament/Bracket/index.ts
@@ -1,0 +1,119 @@
+// frontend/src/pages/Tournament/Bracket/index.ts
+import { Page } from '@/core/Page';
+import CommonLayout from '@/layouts/common/index';
+import { WebSocketManager, WebSocketMessage } from '@/core/WebSocketManager';
+
+interface TournamentMatch {
+  id: number;
+  round: number;
+  match_number: number;
+  player1: string | null;
+  player2: string | null;
+  winner: string | null;
+  scores: {
+    player1: number;
+    player2: number;
+  };
+}
+
+interface TournamentState {
+  status: 'WAITING_PLAYERS' | 'IN_PROGRESS' | 'COMPLETED';
+  current_round: number;
+  participants: string[];
+  matches: TournamentMatch[];
+}
+
+const TournamentBracketPage = new Page({
+  name: 'Tournament/Bracket',
+  config: {
+    layout: CommonLayout,
+  },
+  mounted: async ({ pg }) => {
+    const tournamentId = new URLSearchParams(window.location.search).get('id');
+    
+    if (!tournamentId) {
+      showError('Tournament ID is missing');
+      window.location.href = '/tournament';
+      return;
+    }
+
+    const wsManager = new WebSocketManager();
+
+    wsManager.on('connected', () => {
+      wsManager.send({ type: 'join_tournament' });
+    });
+
+    wsManager.on('tournament_state', (message: WebSocketMessage) => {
+      const state = message.state as TournamentState;
+      updateBracket(state);
+    });
+
+    wsManager.on('error', (message: string) => {
+      showError(message);
+    });
+
+    // WebSocket接続を開始
+    const username = localStorage.getItem('username') || 'testuser';
+    const wsUrl = `ws://${window.location.host}/ws/tournament/${tournamentId}/${username}/`;
+    wsManager.connect(wsUrl);
+
+    // クリーンアップ
+    return () => {
+      wsManager.disconnect();
+    };
+
+    function updateBracket(state: TournamentState) {
+      // 準決勝の表示
+      const semifinalsElement = document.getElementById('semifinals');
+      if (semifinalsElement) {
+        const semifinalMatches = state.matches.filter(m => m.round === 1);
+        semifinalsElement.innerHTML = semifinalMatches.map(match => 
+          createMatchElement(match, state.current_round === 1)
+        ).join('');
+      }
+
+      // 決勝の表示
+      const finalsElement = document.getElementById('finals');
+      if (finalsElement) {
+        const finalMatch = state.matches.find(m => m.round === 2);
+        if (finalMatch) {
+          finalsElement.innerHTML = createMatchElement(finalMatch, state.current_round === 2);
+        }
+      }
+    }
+
+    function createMatchElement(match: TournamentMatch, isCurrent: boolean): string {
+      return `
+        <div class="match ${isCurrent ? 'current' : ''}">
+          ${createPlayerElement(match.player1, match.scores.player1, match.winner === match.player1)}
+          ${createPlayerElement(match.player2, match.scores.player2, match.winner === match.player2)}
+        </div>
+      `;
+    }
+
+    function createPlayerElement(playerName: string | null, score: number, isWinner: boolean): string {
+      if (!playerName) {
+        return `<div class="match-player empty">
+          <span class="player-name">TBD</span>
+          <span class="player-score">-</span>
+        </div>`;
+      }
+
+      return `<div class="match-player ${isWinner ? 'winner' : ''}">
+        <span class="player-name">${playerName}</span>
+        <span class="player-score">${score}</span>
+      </div>`;
+    }
+
+    function showError(message: string) {
+      const errorContainer = document.getElementById('error-container');
+      if (errorContainer) {
+        errorContainer.innerHTML = `
+          <div class="error-message">${message}</div>
+        `;
+      }
+    }
+  },
+});
+
+export default TournamentBracketPage;

--- a/frontend/src/pages/Tournament/Bracket/index.ts
+++ b/frontend/src/pages/Tournament/Bracket/index.ts
@@ -2,26 +2,7 @@
 import { Page } from '@/core/Page';
 import CommonLayout from '@/layouts/common/index';
 import { WebSocketManager, WebSocketMessage } from '@/core/WebSocketManager';
-
-interface TournamentMatch {
-  id: number;
-  round: number;
-  match_number: number;
-  player1: string | null;
-  player2: string | null;
-  winner: string | null;
-  scores: {
-    player1: number;
-    player2: number;
-  };
-}
-
-interface TournamentState {
-  status: 'WAITING_PLAYERS' | 'IN_PROGRESS' | 'COMPLETED';
-  current_round: number;
-  participants: string[];
-  matches: TournamentMatch[];
-}
+import { TournamentState, TournamentMatch } from '@/types/tournament';
 
 const TournamentBracketPage = new Page({
   name: 'Tournament/Bracket',

--- a/frontend/src/pages/Tournament/Bracket/style.css
+++ b/frontend/src/pages/Tournament/Bracket/style.css
@@ -1,0 +1,126 @@
+/* frontend/src/pages/Tournament/Bracket/style.css */
+.tournament-bracket-container {
+  max-width: 1200px;
+  margin: 20px auto;
+  padding: 30px;
+  background-color: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.tournament-header {
+  text-align: center;
+  margin-bottom: 40px;
+}
+
+.tournament-header h1 {
+  color: #1f2937;
+  font-size: 24px;
+  font-weight: bold;
+}
+
+.bracket {
+  display: flex;
+  justify-content: space-around;
+  align-items: flex-start;
+  padding: 20px 0;
+  position: relative;
+}
+
+/* ラウンドのスタイル */
+.round {
+  flex: 1;
+  padding: 0 20px;
+  position: relative;
+}
+
+.round h2 {
+  text-align: center;
+  color: #4b5563;
+  margin-bottom: 20px;
+  font-size: 18px;
+}
+
+/* マッチのスタイル */
+.match {
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 15px;
+  margin: 20px 0;
+  position: relative;
+}
+
+.match-player {
+  padding: 10px;
+  margin: 5px 0;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.match-player.winner {
+  border-color: #059669;
+  background-color: #ecfdf5;
+}
+
+.player-name {
+  font-weight: 500;
+  color: #1f2937;
+}
+
+.player-score {
+  color: #6b7280;
+  font-weight: bold;
+}
+
+/* ブラケットライン */
+.match::after {
+  content: '';
+  position: absolute;
+  right: -20px;
+  top: 50%;
+  width: 20px;
+  height: 2px;
+  background: #e5e7eb;
+}
+
+.finals .match::after {
+  display: none;
+}
+
+/* 接続線 */
+.connecting-line {
+  position: absolute;
+  background: #e5e7eb;
+}
+
+/* 空のスロット */
+.match-player.empty {
+  color: #9ca3af;
+  font-style: italic;
+}
+
+/* 現在の試合をハイライト */
+.match.current {
+  border: 2px solid #3b82f6;
+  box-shadow: 0 2px 4px rgba(59, 130, 246, 0.1);
+}
+
+/* レスポンシブ対応 */
+@media (max-width: 768px) {
+  .bracket {
+    flex-direction: column;
+  }
+
+  .round {
+    padding: 20px 0;
+  }
+
+  .match::after {
+    display: none;
+  }
+}

--- a/frontend/src/pages/Tournament/Game/index.html
+++ b/frontend/src/pages/Tournament/Game/index.html
@@ -1,20 +1,5 @@
-<!-- frontend/src/pages/MultiPlay/Game/index.html -->
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Multiplayer Pong</title>
-</head>
-<body>
-  <div id="game-container">
-    <div id="score-board"></div>
-    <div id="game-canvas"></div>
-  </div>
-  <div id="game-over" class="hidden">
-    <h1>Game Over</h1>
-    <p>Winner: <span id="winner-name"></span></p>
-    <button id="exit-btn">Exit to Menu</button>
-  </div>
-</body>
-</html>
+<!-- frontend/src/pages/Tournament/Game/index.html -->
+<div id="game-container">
+  <div id="score-board"></div>
+  <div id="game-canvas"></div>
+</div>

--- a/frontend/src/pages/Tournament/Game/index.html
+++ b/frontend/src/pages/Tournament/Game/index.html
@@ -1,0 +1,20 @@
+<!-- frontend/src/pages/MultiPlay/Game/index.html -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Multiplayer Pong</title>
+</head>
+<body>
+  <div id="game-container">
+    <div id="score-board"></div>
+    <div id="game-canvas"></div>
+  </div>
+  <div id="game-over" class="hidden">
+    <h1>Game Over</h1>
+    <p>Winner: <span id="winner-name"></span></p>
+    <button id="exit-btn">Exit to Menu</button>
+  </div>
+</body>
+</html>

--- a/frontend/src/pages/Tournament/Game/index.ts
+++ b/frontend/src/pages/Tournament/Game/index.ts
@@ -1,0 +1,137 @@
+// frontend/src/pages/Tournament/Game/index.ts
+import { Page } from '@/core/Page';
+import CommonLayout from '@/layouts/common/index';
+import { GameRenderer } from '@/pages/MultiPlay/Game/game_renderer';
+import { WS_URL } from '@/config/config';
+
+const TournamentGamePage = new Page({
+  name: 'Tournament/Game',
+  config: {
+    layout: CommonLayout,
+  },
+  mounted: async ({ pg }) => {
+    // パラメータの取得と検証
+    const urlParams = new URLSearchParams(window.location.search);
+    const tournamentId = urlParams.get('id');
+    const username = localStorage.getItem('username');
+
+    if (!tournamentId || !username) {
+      console.error('Missing required params:', { tournamentId, username });
+      window.location.href = '/tournament';
+      return;
+    }
+
+    // ゲームコンテナの取得
+    const container = document.getElementById('game-canvas');
+    if (!container) {
+      console.error('Game container not found');
+      return;
+    }
+
+    // 現在のマッチを取得して、player1かどうかを判定
+    try {
+      const response = await fetch(`/api/tournaments/${tournamentId}/current-match`);
+      if (!response.ok) throw new Error('Failed to fetch match info');
+      const matchData = await response.json();
+      const isPlayer1 = matchData.player1 === username;
+
+      // GameRendererの初期化（MultiPlayと同じレンダラーを使用）
+      const renderer = new GameRenderer(container, isPlayer1);
+      const keyState = {
+        ArrowLeft: false,
+        ArrowRight: false,
+      };
+
+      // WebSocket接続
+      const socket = new WebSocket(`${WS_URL}/ws/tournament/${tournamentId}/game/${username}/`);
+      let wsConnected = false;
+
+      socket.onopen = () => {
+        console.log('Game WebSocket connected');
+        wsConnected = true;
+      };
+
+      socket.onmessage = async (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (data.type === 'state_update') {
+            renderer.updateState(data.state);
+            updateScoreBoard(data.state.score);
+
+            if (!data.state.is_active) {
+              // 試合終了時の処理
+              socket.close();
+              const scores = {
+                player1: data.state.score[matchData.player1],
+                player2: data.state.score[matchData.player2],
+                opponent: username === matchData.player1 ? matchData.player2 : matchData.player1
+              };
+              localStorage.setItem('finalScore', JSON.stringify(scores));
+
+              // トーナメントの次の試合または結果ページへ
+              window.location.href = `/tournament/waiting?id=${tournamentId}`;
+            }
+          }
+        } catch (error) {
+          console.error('Error handling WebSocket message:', error);
+        }
+      };
+
+      // キー入力の処理はMultiPlayと同じ
+      const handleKeyChange = (e: KeyboardEvent, isPressed: boolean) => {
+        if (!wsConnected) return;
+
+        if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+          keyState[e.key] = isPressed;
+          e.preventDefault();
+
+          const currentX = renderer.getPaddlePosition(username) ?? 0;
+          const moveAmount = 10;
+          let movement = 0;
+
+          if (keyState.ArrowLeft) movement -= moveAmount;
+          if (keyState.ArrowRight) movement += moveAmount;
+
+          if (!isPlayer1) movement *= -1;
+
+          const newPosition = currentX + movement;
+
+          if (movement !== 0) {
+            socket.send(JSON.stringify({
+              type: 'move',
+              position: newPosition,
+            }));
+          }
+        }
+      };
+
+      // キーイベントリスナーの設定
+      document.addEventListener('keydown', e => handleKeyChange(e, true));
+      document.addEventListener('keyup', e => handleKeyChange(e, false));
+
+      // クリーンアップ関数を返す
+      return () => {
+        document.removeEventListener('keydown', e => handleKeyChange(e, true));
+        document.removeEventListener('keyup', e => handleKeyChange(e, false));
+        socket.close();
+        renderer.dispose();
+      };
+
+    } catch (error) {
+      console.error('Error setting up game:', error);
+      window.location.href = '/tournament';
+    }
+
+    function updateScoreBoard(score: any) {
+      const scoreBoard = document.getElementById('score-board');
+      if (!scoreBoard) return;
+
+      const [player1Name, player2Name] = Object.keys(score);
+      const player1Score = score[player1Name] || 0;
+      const player2Score = score[player2Name] || 0;
+      scoreBoard.textContent = `${player1Score} - ${player2Score}`;
+    }
+  },
+});
+
+export default TournamentGamePage;

--- a/frontend/src/pages/Tournament/Game/index.ts
+++ b/frontend/src/pages/Tournament/Game/index.ts
@@ -31,7 +31,7 @@ const TournamentGamePage = new Page({
 
     try {
       // 現在のマッチ情報を取得
-      const response = await fetch(`${API_URL}/tournaments/${tournamentId}/current-match/`);
+      const response = await fetch(`${API_URL}/api/tournaments/${tournamentId}/current-match/`);
       if (!response.ok) throw new Error('Failed to fetch match info');
       const matchData = await response.json();
 

--- a/frontend/src/pages/Tournament/Game/index.ts
+++ b/frontend/src/pages/Tournament/Game/index.ts
@@ -3,6 +3,7 @@ import { Page } from '@/core/Page';
 import CommonLayout from '@/layouts/common/index';
 import { GameRenderer } from '@/pages/MultiPlay/Game/game_renderer';
 import { WS_URL } from '@/config/config';
+import { API_URL } from '@/config/config';
 
 const TournamentGamePage = new Page({
   name: 'Tournament/Game',
@@ -30,7 +31,7 @@ const TournamentGamePage = new Page({
 
     try {
       // 現在のマッチ情報を取得
-      const response = await fetch(`/api/tournaments/${tournamentId}/current-match`);
+      const response = await fetch(`${API_URL}/tournaments/${tournamentId}/current-match/`);
       if (!response.ok) throw new Error('Failed to fetch match info');
       const matchData = await response.json();
 

--- a/frontend/src/pages/Tournament/Game/style.css
+++ b/frontend/src/pages/Tournament/Game/style.css
@@ -1,4 +1,4 @@
-/* frontend/src/pages/MultiPlay/Game/style.css */
+/* frontend/src/pages/Tournament/Game/style.css */
 #game-container {
   display: flex;
   flex-direction: column;
@@ -23,36 +23,4 @@
   font-weight: bold;
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
   z-index: 10;
-}
-
-#game-over {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background-color: rgba(0, 0, 0, 0.8);
-  padding: 2rem;
-  border-radius: 8px;
-  text-align: center;
-  color: #ffffff;
-  z-index: 20;
-}
-
-#game-over.hidden {
-  display: none;
-}
-
-#exit-btn {
-  margin-top: 1rem;
-  padding: 0.5rem 1rem;
-  background-color: #4a90e2;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 1rem;
-}
-
-#exit-btn:hover {
-  background-color: #357abd;
 }

--- a/frontend/src/pages/Tournament/Game/style.css
+++ b/frontend/src/pages/Tournament/Game/style.css
@@ -1,0 +1,58 @@
+/* frontend/src/pages/MultiPlay/Game/style.css */
+#game-container {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  width: 60vw;
+  height: 60vh;
+  background-color: #1a1a1a;
+}
+
+#game-canvas {
+  width: 100%;
+  height: 100%;
+}
+
+#score-board {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: #ffffff;
+  font-size: 2rem;
+  font-weight: bold;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+  z-index: 10;
+}
+
+#game-over {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: rgba(0, 0, 0, 0.8);
+  padding: 2rem;
+  border-radius: 8px;
+  text-align: center;
+  color: #ffffff;
+  z-index: 20;
+}
+
+#game-over.hidden {
+  display: none;
+}
+
+#exit-btn {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background-color: #4a90e2;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+#exit-btn:hover {
+  background-color: #357abd;
+}

--- a/frontend/src/pages/Tournament/List/index.html
+++ b/frontend/src/pages/Tournament/List/index.html
@@ -1,0 +1,16 @@
+<!-- frontend/src/pages/Tournament/List/index.html -->
+<div class="tournament-container">
+  <div class="tournament-header">
+    <h1>Tournaments</h1>
+  </div>
+  
+  <div id="error-container"></div>
+
+  <div class="tournament-actions">
+    <button id="create-tournament" class="btn-primary">Create New Tournament</button>
+  </div>
+  
+  <div class="tournament-list">
+    <!-- トーナメントカードが動的に追加される -->
+  </div>
+</div>

--- a/frontend/src/pages/Tournament/List/index.ts
+++ b/frontend/src/pages/Tournament/List/index.ts
@@ -45,8 +45,11 @@ const TournamentListPage = new Page({
             throw new Error(`Failed to create tournament: ${response.status} ${errorText}`);
           }
           
-          // 作成後、一覧を再取得
-          fetchTournaments();
+          // レスポンスからトーナメントIDを取得
+          const tournament = await response.json();
+          
+          // 待機室へ遷移
+          window.location.href = `/tournament/waiting?id=${tournament.id}`;
         } catch (error) {
           console.error('Tournament creation catch error:', error);
           showError(`Failed to create tournament: ${error.message}`);

--- a/frontend/src/pages/Tournament/List/index.ts
+++ b/frontend/src/pages/Tournament/List/index.ts
@@ -29,24 +29,18 @@ const TournamentListPage = new Page({
             },
             body: JSON.stringify({
               name: `Tournament ${new Date().toLocaleString()}`,
+              participants: [localStorage.getItem('username')],
             }),
           });
+
+          if (!response.ok) {
+            const errorData = await response.json();
+            throw new Error(`Failed to create tournament: ${JSON.stringify(errorData)}`);
+          }
 
           console.log('Response status:', response.status);
           const tournament = await response.json();
           console.log('tournament data:', tournament);
-
-          if (!response.ok) {
-            throw new Error(`Failed to create tournament: ${response.status}`);
-          }
-          if (!tournament.id) {
-            console.log('Tournament creation successful but no ID received:', tournament);
-            throw new Error('Tournament ID not received');
-          }
-
-          // レスポンスからトーナメントIDを取得
-          console.log('Created tournament:', tournament); // デバッグ用
-
           if (!tournament.id) {
             throw new Error('Tournament ID not received');
           }

--- a/frontend/src/pages/Tournament/List/index.ts
+++ b/frontend/src/pages/Tournament/List/index.ts
@@ -158,7 +158,7 @@ const TournamentListPage = new Page({
     }
 
     function viewTournament(id: string) {
-      window.location.href = `/tournament/${id}`;
+      window.location.href = `/tournament/waiting?id=${id}`;
     }
 
     async function joinTournament(id: string) {

--- a/frontend/src/pages/Tournament/List/index.ts
+++ b/frontend/src/pages/Tournament/List/index.ts
@@ -1,5 +1,6 @@
 // frontend/src/pages/Tournament/List/index.ts
 import { Page } from '@/core/Page';
+import { API_URL } from '@/config/config';
 import CommonLayout from '@/layouts/common/index';
 
 interface Tournament {
@@ -21,7 +22,7 @@ const TournamentListPage = new Page({
     if (createButton instanceof HTMLElement) {
       createButton.addEventListener('click', async () => {
         try {
-          const response = await fetch('/api/tournaments', {
+          const response = await fetch(`${API_URL}/tournaments/`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -53,7 +54,7 @@ const TournamentListPage = new Page({
 
     async function fetchTournaments() {
       try {
-        const response = await fetch('/api/tournaments');
+        const response = await fetch(`${API_URL}/tournaments/`);
         if (!response.ok) throw new Error('Failed to fetch tournaments');
         const tournaments = await response.json();
         displayTournaments(tournaments);
@@ -132,7 +133,7 @@ const TournamentListPage = new Page({
 
     async function joinTournament(id: string) {
       try {
-        const response = await fetch(`/api/tournaments/${id}/join`, {
+        const response = await fetch(`${API_URL}/tournaments/${id}/join/`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/frontend/src/pages/Tournament/List/index.ts
+++ b/frontend/src/pages/Tournament/List/index.ts
@@ -1,0 +1,162 @@
+// frontend/src/pages/Tournament/List/index.ts
+import { Page } from '@/core/Page';
+import CommonLayout from '@/layouts/common/index';
+
+interface Tournament {
+  id: number;
+  name: string;
+  status: 'WAITING_PLAYERS' | 'IN_PROGRESS' | 'COMPLETED';
+  created_at: string;
+  participants: number;
+}
+
+const TournamentListPage = new Page({
+  name: 'Tournament/List',
+  config: {
+    layout: CommonLayout,
+  },
+  mounted: async ({ pg }) => {
+    const refreshInterval = setInterval(fetchTournaments, 5000);
+
+    // 初期表示時にトーナメント一覧を取得
+    fetchTournaments();
+
+    // クリーンアップ
+    return () => {
+      clearInterval(refreshInterval);
+    };
+
+    async function fetchTournaments() {
+      try {
+        const response = await fetch('/api/tournaments');
+        if (!response.ok) throw new Error('Failed to fetch tournaments');
+        const tournaments = await response.json();
+        displayTournaments(tournaments);
+      } catch (error) {
+        showError('Failed to load tournaments');
+      }
+    }
+
+    function displayTournaments(tournaments: Tournament[]) {
+      const listElement = document.querySelector('.tournament-list');
+      if (!listElement) return;
+
+      listElement.innerHTML = tournaments.map(tournament => `
+        <div class="tournament-card" data-id="${tournament.id}">
+          <h3>${tournament.name}</h3>
+          <span class="tournament-card-status status-${tournament.status.toLowerCase()}">
+            ${formatStatus(tournament.status)}
+          </span>
+          <div class="tournament-card-info">
+            <div>Created: ${formatDate(tournament.created_at)}</div>
+            <div>Participants: ${tournament.participants}/4</div>
+          </div>
+          <div class="tournament-card-actions">
+            ${renderActionButton(tournament)}
+          </div>
+        </div>
+      `).join('');
+
+      // カードのクリックイベントを設定
+      setupEventListeners(listElement);
+    }
+
+    function setupEventListeners(listElement: Element) {
+      // トーナメントカードのクリックイベント
+      listElement.querySelectorAll('.tournament-card').forEach(card => {
+        card.addEventListener('click', (e) => {
+          if (e.target instanceof HTMLButtonElement) return;
+          const id = card.getAttribute('data-id');
+          if (id) viewTournament(id);
+        });
+      });
+
+      // 参加ボタンのクリックイベント
+      listElement.querySelectorAll('.join-tournament').forEach(button => {
+        button.addEventListener('click', async (e) => {
+          e.stopPropagation();
+          const id = button.getAttribute('data-id');
+          if (id) await joinTournament(id);
+        });
+      });
+    }
+
+    function renderActionButton(tournament: Tournament) {
+      if (tournament.status === 'WAITING_PLAYERS' && tournament.participants < 4) {
+        return `<button class="btn-primary join-tournament" data-id="${tournament.id}">Join</button>`;
+      }
+      return '';
+    }
+
+    function formatStatus(status: string): string {
+      switch (status) {
+        case 'WAITING_PLAYERS': return 'Waiting for Players';
+        case 'IN_PROGRESS': return 'In Progress';
+        case 'COMPLETED': return 'Completed';
+        default: return status;
+      }
+    }
+
+    function formatDate(dateString: string): string {
+      return new Date(dateString).toLocaleString();
+    }
+
+    function viewTournament(id: string) {
+      window.location.href = `/tournament/${id}`;
+    }
+
+    async function joinTournament(id: string) {
+      try {
+        const response = await fetch(`/api/tournaments/${id}/join`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        if (!response.ok) throw new Error('Failed to join tournament');
+        
+        // 参加成功後、待機ページへ遷移
+        window.location.href = `/tournament/waiting?id=${id}`;
+      } catch (error) {
+        showError('Failed to join tournament');
+      }
+    }
+
+    function showError(message: string) {
+      const errorContainer = document.getElementById('error-container');
+      if (errorContainer) {
+        errorContainer.innerHTML = `
+          <div class="error-message">${message}</div>
+        `;
+      }
+    }
+
+    // 新規トーナメント作成ボタンのイベントリスナー
+    const createButton = document.getElementById('create-tournament');
+    if (createButton) {
+      createButton.addEventListener('click', async () => {
+        try {
+          const response = await fetch('/api/tournaments', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              name: `Tournament ${new Date().toLocaleString()}`
+            }),
+          });
+
+          if (!response.ok) throw new Error('Failed to create tournament');
+          
+          // 作成後、一覧を再取得
+          fetchTournaments();
+        } catch (error) {
+          showError('Failed to create tournament');
+        }
+      });
+    }
+  },
+});
+
+export default TournamentListPage;

--- a/frontend/src/pages/Tournament/List/index.ts
+++ b/frontend/src/pages/Tournament/List/index.ts
@@ -34,19 +34,18 @@ const TournamentListPage = new Page({
 
           // FIXME: トーナメントID検証用debug出力2
           console.log('Response status:', response.status);
-          const responseData = await response.json();
-          console.log('Response data:', responseData);
+          const tournament = await response.json();
+          console.log('tournament data:', tournament);
 
           if (!response.ok) {
             throw new Error(`Failed to create tournament: ${response.status}`);
           }
-          if (!responseData.id) {
-            console.log('Tournament creation successful but no ID received:', responseData);
+          if (!tournament.id) {
+            console.log('Tournament creation successful but no ID received:', tournament);
             throw new Error('Tournament ID not received');
           }
 
           // レスポンスからトーナメントIDを取得
-          const tournament = await response.json();
           console.log('Created tournament:', tournament); // デバッグ用
 
           if (!tournament.id) {

--- a/frontend/src/pages/Tournament/List/index.ts
+++ b/frontend/src/pages/Tournament/List/index.ts
@@ -16,6 +16,31 @@ const TournamentListPage = new Page({
     layout: CommonLayout,
   },
   mounted: async ({ pg }) => {
+    // 新規トーナメント作成ボタンのイベントリスナー
+    const createButton = document.getElementById('create-tournament');
+    if (createButton instanceof HTMLElement) {
+      createButton.addEventListener('click', async () => {
+        try {
+          const response = await fetch('/api/tournaments', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              name: `Tournament ${new Date().toLocaleString()}`
+            }),
+          });
+
+          if (!response.ok) throw new Error('Failed to create tournament');
+          
+          // 作成後、一覧を再取得
+          fetchTournaments();
+        } catch (error) {
+          showError('Failed to create tournament');
+        }
+      });
+    }
+
     const refreshInterval = setInterval(fetchTournaments, 5000);
 
     // 初期表示時にトーナメント一覧を取得
@@ -130,31 +155,6 @@ const TournamentListPage = new Page({
           <div class="error-message">${message}</div>
         `;
       }
-    }
-
-    // 新規トーナメント作成ボタンのイベントリスナー
-    const createButton = document.getElementById('create-tournament');
-    if (createButton) {
-      createButton.addEventListener('click', async () => {
-        try {
-          const response = await fetch('/api/tournaments', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-              name: `Tournament ${new Date().toLocaleString()}`
-            }),
-          });
-
-          if (!response.ok) throw new Error('Failed to create tournament');
-          
-          // 作成後、一覧を再取得
-          fetchTournaments();
-        } catch (error) {
-          showError('Failed to create tournament');
-        }
-      });
     }
   },
 });

--- a/frontend/src/pages/Tournament/List/index.ts
+++ b/frontend/src/pages/Tournament/List/index.ts
@@ -81,7 +81,7 @@ const TournamentListPage = new Page({
         const tournaments = await response.json();
         displayTournaments(tournaments);
       } catch (error) {
-        showError('Failed to load tournaments');
+        showError('Failed to load tournaments on list');
       }
     }
 
@@ -99,7 +99,7 @@ const TournamentListPage = new Page({
           </span>
           <div class="tournament-card-info">
             <div>Created: ${formatDate(tournament.created_at)}</div>
-            <div>Participants: ${tournament.participants}/4</div>
+            <div>Participants: ${tournament.participants.length}/4</div>
           </div>
           <div class="tournament-card-actions">
             ${renderActionButton(tournament)}
@@ -134,7 +134,7 @@ const TournamentListPage = new Page({
     }
 
     function renderActionButton(tournament: Tournament) {
-      if (tournament.status === 'WAITING_PLAYERS' && tournament.participants < 4) {
+      if (tournament.status === 'WAITING_PLAYERS' && tournament.participants.length < 4) {
         return `<button class="btn-primary join-tournament" data-id="${tournament.id}">Join</button>`;
       }
       return '';

--- a/frontend/src/pages/Tournament/List/index.ts
+++ b/frontend/src/pages/Tournament/List/index.ts
@@ -22,7 +22,7 @@ const TournamentListPage = new Page({
     if (createButton instanceof HTMLElement) {
       createButton.addEventListener('click', async () => {
         try {
-          const response = await fetch(`${API_URL}/tournaments/`, {
+          const response = await fetch(`${API_URL}/api/tournaments/`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -32,12 +32,23 @@ const TournamentListPage = new Page({
             }),
           });
 
-          if (!response.ok) throw new Error('Failed to create tournament');
+          if (!response.ok) {
+            // エラーレスポンスの本文を取得
+            const errorText = await response.text();
+            console.error('Tournament creation error:', {
+              status: response.status,
+              statusText: response.statusText,
+              errorBody: errorText
+            });
+            
+            throw new Error(`Failed to create tournament: ${response.status} ${errorText}`);
+          }
           
           // 作成後、一覧を再取得
           fetchTournaments();
         } catch (error) {
-          showError('Failed to create tournament');
+          console.error('Tournament creation catch error:', error);
+          showError(`Failed to create tournament: ${error.message}`);
         }
       });
     }
@@ -54,7 +65,7 @@ const TournamentListPage = new Page({
 
     async function fetchTournaments() {
       try {
-        const response = await fetch(`${API_URL}/tournaments/`);
+        const response = await fetch(`${API_URL}/api/tournaments/`);
         if (!response.ok) throw new Error('Failed to fetch tournaments');
         const tournaments = await response.json();
         displayTournaments(tournaments);
@@ -133,7 +144,7 @@ const TournamentListPage = new Page({
 
     async function joinTournament(id: string) {
       try {
-        const response = await fetch(`${API_URL}/tournaments/${id}/join/`, {
+        const response = await fetch(`${API_URL}/api/tournaments/${id}/join/`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/frontend/src/pages/Tournament/List/index.ts
+++ b/frontend/src/pages/Tournament/List/index.ts
@@ -26,6 +26,7 @@ const TournamentListPage = new Page({
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
+              'Authorization': `Token ${localStorage.getItem('token')}`,
             },
             body: JSON.stringify({
               name: `Tournament ${new Date().toLocaleString()}`
@@ -65,7 +66,11 @@ const TournamentListPage = new Page({
 
     async function fetchTournaments() {
       try {
-        const response = await fetch(`${API_URL}/api/tournaments/`);
+        const response = await fetch(`${API_URL}/api/tournaments/`, {
+          headers: {
+            'Authorization': `Token ${localStorage.getItem('token')}`, // 認証トークンを追加
+          }
+        });
         if (!response.ok) throw new Error('Failed to fetch tournaments');
         const tournaments = await response.json();
         displayTournaments(tournaments);
@@ -148,9 +153,10 @@ const TournamentListPage = new Page({
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            'Authorization': `Token ${localStorage.getItem('token')}`, // 認証トークンを追加
           },
         });
-
+    
         if (!response.ok) throw new Error('Failed to join tournament');
         
         // 参加成功後、待機ページへ遷移

--- a/frontend/src/pages/Tournament/List/index.ts
+++ b/frontend/src/pages/Tournament/List/index.ts
@@ -32,7 +32,6 @@ const TournamentListPage = new Page({
             }),
           });
 
-          // FIXME: トーナメントID検証用debug出力2
           console.log('Response status:', response.status);
           const tournament = await response.json();
           console.log('tournament data:', tournament);

--- a/frontend/src/pages/Tournament/List/style.css
+++ b/frontend/src/pages/Tournament/List/style.css
@@ -1,0 +1,102 @@
+/* frontend/src/pages/Tournament/List/style.css */
+.tournament-container {
+  max-width: 1200px;
+  margin: 20px auto;
+  padding: 30px;
+  background-color: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.tournament-header {
+  text-align: center;
+  margin-bottom: 30px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.tournament-actions {
+  margin-bottom: 20px;
+  text-align: right;
+}
+
+.btn-primary {
+  background-color: #3b82f6;
+  color: white;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.btn-primary:hover {
+  background-color: #2563eb;
+}
+
+.tournament-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 20px;
+  padding: 20px 0;
+}
+
+.tournament-card {
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 16px;
+  transition: transform 0.2s;
+}
+
+.tournament-card:hover {
+  transform: translateY(-2px);
+}
+
+.tournament-card h3 {
+  color: #1f2937;
+  margin-bottom: 8px;
+  font-size: 18px;
+}
+
+.tournament-card-status {
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 14px;
+  margin-bottom: 12px;
+}
+
+.status-waiting {
+  background-color: #dbeafe;
+  color: #1e40af;
+}
+
+.status-in-progress {
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+.status-completed {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.tournament-card-info {
+  font-size: 14px;
+  color: #4b5563;
+  margin-bottom: 16px;
+}
+
+.tournament-card-actions {
+  text-align: right;
+}
+
+.error-message {
+  background-color: #fee2e2;
+  border: 1px solid #ef4444;
+  color: #991b1b;
+  padding: 10px 15px;
+  margin-bottom: 20px;
+  border-radius: 4px;
+}

--- a/frontend/src/pages/Tournament/Result/index.html
+++ b/frontend/src/pages/Tournament/Result/index.html
@@ -1,0 +1,20 @@
+<!-- frontend/src/pages/Tournament/Result/index.html -->
+<div class="result-container">
+  <div class="result-header">
+    <h1>Tournament Results</h1>
+  </div>
+
+  <div class="result-content">
+    <div id="winner-display">
+      <!-- 優勝者情報が動的に追加される -->
+    </div>
+
+    <div class="tournament-summary" id="tournament-summary">
+      <!-- トーナメント結果サマリーが動的に追加される -->
+    </div>
+  </div>
+
+  <div class="result-actions">
+    <button id="return-button" class="btn-primary">Return to Mode Selection</button>
+  </div>
+</div>

--- a/frontend/src/pages/Tournament/Result/index.ts
+++ b/frontend/src/pages/Tournament/Result/index.ts
@@ -38,7 +38,7 @@ const TournamentResultPage = new Page({
 
     try {
       // トーナメント結果を取得
-      const response = await fetch(`${API_URL}/tournaments/${tournamentId}/result/`);
+      const response = await fetch(`${API_URL}/api/tournaments/${tournamentId}/result/`);
       if (!response.ok) throw new Error('Failed to fetch tournament result');
       const result: TournamentResult = await response.json();
 

--- a/frontend/src/pages/Tournament/Result/index.ts
+++ b/frontend/src/pages/Tournament/Result/index.ts
@@ -1,6 +1,7 @@
 // frontend/src/pages/Tournament/Result/index.ts
 import { Page } from '@/core/Page';
 import CommonLayout from '@/layouts/common/index';
+import { API_URL } from '@/config/config';
 
 interface TournamentMatch {
   id: number;
@@ -37,7 +38,7 @@ const TournamentResultPage = new Page({
 
     try {
       // トーナメント結果を取得
-      const response = await fetch(`/api/tournaments/${tournamentId}/result`);
+      const response = await fetch(`${API_URL}/tournaments/${tournamentId}/result/`);
       if (!response.ok) throw new Error('Failed to fetch tournament result');
       const result: TournamentResult = await response.json();
 

--- a/frontend/src/pages/Tournament/Result/index.ts
+++ b/frontend/src/pages/Tournament/Result/index.ts
@@ -1,0 +1,101 @@
+// frontend/src/pages/Tournament/Result/index.ts
+import { Page } from '@/core/Page';
+import CommonLayout from '@/layouts/common/index';
+
+interface TournamentMatch {
+  id: number;
+  round: number;
+  match_number: number;
+  player1: string;
+  player2: string;
+  winner: string;
+  scores: {
+    player1: number;
+    player2: number;
+  };
+}
+
+interface TournamentResult {
+  tournament_id: number;
+  winner: string;
+  matches: TournamentMatch[];
+  completed_at: string;
+}
+
+const TournamentResultPage = new Page({
+  name: 'Tournament/Result',
+  config: {
+    layout: CommonLayout,
+  },
+  mounted: async ({ pg }) => {
+    const tournamentId = new URLSearchParams(window.location.search).get('id');
+    
+    if (!tournamentId) {
+      window.location.href = '/tournament';
+      return;
+    }
+
+    try {
+      // トーナメント結果を取得
+      const response = await fetch(`/api/tournaments/${tournamentId}/result`);
+      if (!response.ok) throw new Error('Failed to fetch tournament result');
+      const result: TournamentResult = await response.json();
+
+      // 優勝者表示を更新
+      const winnerDisplay = document.getElementById('winner-display');
+      if (winnerDisplay) {
+        winnerDisplay.innerHTML = `
+          <div class="winner-title">Tournament Champion</div>
+          <div class="winner-name">${result.winner}</div>
+          <div class="completed-at">Completed at: ${formatDate(result.completed_at)}</div>
+        `;
+      }
+
+      // トーナメントサマリーを更新
+      const summaryDisplay = document.getElementById('tournament-summary');
+      if (summaryDisplay) {
+        const matches = [...result.matches].sort((a, b) => {
+          // ラウンドとマッチ番号でソート
+          if (a.round !== b.round) return a.round - b.round;
+          return a.match_number - b.match_number;
+        });
+
+        summaryDisplay.innerHTML = matches.map(match => `
+          <div class="match-result">
+            <h3>${match.round === 1 ? 'Semifinal' : 'Final'} #${match.match_number}</h3>
+            <div class="match-score">
+              <div class="player-info">
+                <span class="player-name">${match.player1}</span>
+                <span class="player-score">${match.scores.player1}</span>
+                ${match.winner === match.player1 ? '<span class="winner-mark">Winner</span>' : ''}
+              </div>
+              <div class="player-info">
+                <span class="player-name">${match.player2}</span>
+                <span class="player-score">${match.scores.player2}</span>
+                ${match.winner === match.player2 ? '<span class="winner-mark">Winner</span>' : ''}
+              </div>
+            </div>
+          </div>
+        `).join('');
+      }
+
+      // 戻るボタンのイベントリスナー
+      const returnButton = document.getElementById('return-button');
+      if (returnButton instanceof HTMLElement) {
+        returnButton.addEventListener('click', () => {
+          window.location.href = '/modes';
+        });
+      }
+
+    } catch (error) {
+      console.error('Error fetching tournament result:', error);
+      window.location.href = '/modes';
+    }
+
+    function formatDate(dateString: string): string {
+      return new Date(dateString).toLocaleString();
+    }
+  },
+});
+
+export default TournamentResultPage;

--- a/frontend/src/pages/Tournament/Result/style.css
+++ b/frontend/src/pages/Tournament/Result/style.css
@@ -1,0 +1,113 @@
+/* frontend/src/pages/Tournament/Result/style.css */
+.result-container {
+  max-width: 800px;
+  margin: 20px auto;
+  padding: 30px;
+  background-color: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.result-header {
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+.result-header h1 {
+  color: #1f2937;
+  font-size: 24px;
+  font-weight: bold;
+}
+
+.result-content {
+  margin-bottom: 40px;
+}
+
+#winner-display {
+  text-align: center;
+  padding: 30px;
+  background-color: #ecfdf5;
+  border-radius: 8px;
+  margin-bottom: 30px;
+}
+
+.winner-title {
+  color: #047857;
+  font-size: 28px;
+  font-weight: bold;
+  margin-bottom: 15px;
+}
+
+.winner-name {
+  color: #059669;
+  font-size: 36px;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.tournament-summary {
+  padding: 20px;
+  background-color: #f9fafb;
+  border-radius: 8px;
+}
+
+.match-result {
+  margin: 15px 0;
+  padding: 15px;
+  background-color: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+}
+
+.match-result h3 {
+  color: #4b5563;
+  font-size: 16px;
+  margin-bottom: 10px;
+}
+
+.match-score {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px;
+  background-color: #f3f4f6;
+  border-radius: 4px;
+}
+
+.player-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.player-name {
+  font-weight: 500;
+}
+
+.player-score {
+  font-weight: bold;
+}
+
+.winner-mark {
+  color: #059669;
+  font-size: 14px;
+}
+
+.result-actions {
+  text-align: center;
+}
+
+.btn-primary {
+  background-color: #3b82f6;
+  color: white;
+  padding: 12px 24px;
+  border: none;
+  border-radius: 6px;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.btn-primary:hover {
+  background-color: #2563eb;
+}

--- a/frontend/src/pages/Tournament/Waiting/index.html
+++ b/frontend/src/pages/Tournament/Waiting/index.html
@@ -1,0 +1,22 @@
+<!-- frontend/src/pages/Tournament/Waiting/index.html -->
+<div class="waiting-room-container">
+  <div class="waiting-room-header">
+    <h1>Tournament Waiting Room</h1>
+    <div id="error-container"></div>
+  </div>
+
+  <div class="waiting-status">
+    <div class="participant-count">
+      Waiting for players: <span id="participant-count">0</span>/4
+    </div>
+  </div>
+
+  <div class="participant-list" id="participant-list">
+    <!-- 参加者リストが動的に追加される -->
+  </div>
+
+  <div class="waiting-room-info">
+    <p>The tournament will start automatically when 4 players join.</p>
+    <button id="leave-tournament" class="btn-secondary">Leave Tournament</button>
+  </div>
+</div>

--- a/frontend/src/pages/Tournament/Waiting/index.html
+++ b/frontend/src/pages/Tournament/Waiting/index.html
@@ -17,6 +17,11 @@
 
   <div class="waiting-room-info">
     <p>The tournament will start automatically when 4 players join.</p>
+    <button id="join-tournament" class="btn-primary">Join Tournament</button>
     <button id="leave-tournament" class="btn-secondary">Leave Tournament</button>
+  </div>
+
+  <div class="waiting-room-info">
+    <p>The tournament will start automatically when 4 players join.</p>
   </div>
 </div>

--- a/frontend/src/pages/Tournament/Waiting/index.ts
+++ b/frontend/src/pages/Tournament/Waiting/index.ts
@@ -1,7 +1,6 @@
-// frontend/src/pages/Tournament/Waiting/index.ts
 import { Page } from '@/core/Page';
 import CommonLayout from '@/layouts/common/index';
-import { WS_URL } from '@/config/config';
+import { WS_URL, API_URL } from '@/config/config';
 import { TournamentState } from '@/types/tournament';
 
 const TournamentWaitingPage = new Page({
@@ -10,7 +9,6 @@ const TournamentWaitingPage = new Page({
     layout: CommonLayout,
   },
   mounted: async ({ pg }) => {
-    // TODO: tournamentIdがundefinedになっているので取得方法がおかしい
     const tournamentId = new URLSearchParams(window.location.search).get('id');
     let socket: WebSocket | null = null;
     
@@ -18,6 +16,34 @@ const TournamentWaitingPage = new Page({
       showError('Tournament ID is missing');
       window.location.href = '/tournament';
       return;
+    }
+
+    // Join tournament button handler
+    const joinButton = document.getElementById('join-tournament');
+    if (joinButton instanceof HTMLElement) {
+      joinButton.addEventListener('click', async () => {
+        try {
+          const response = await fetch(`${API_URL}/api/tournaments/${tournamentId}/join/`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Token ${localStorage.getItem('token')}`,
+            },
+          });
+
+          if (!response.ok) {
+            throw new Error('Failed to join tournament');
+          }
+
+          // WebSocket接続を更新
+          if (socket) {
+            socket.send(JSON.stringify({ type: 'join_tournament' }));
+          }
+
+        } catch (error) {
+          showError('Failed to join tournament');
+        }
+      });
     }
 
     // Leave tournament button handler
@@ -117,6 +143,17 @@ const TournamentWaitingPage = new Page({
             </div>
           `;
         }).join('');
+      }
+
+      // Update button visibility
+      const username = localStorage.getItem('username');
+      const isParticipant = state.participants.includes(username);
+      const joinButton = document.getElementById('join-tournament');
+      const leaveButton = document.getElementById('leave-tournament');
+      
+      if (joinButton && leaveButton) {
+        joinButton.style.display = isParticipant ? 'none' : 'inline-block';
+        leaveButton.style.display = isParticipant ? 'inline-block' : 'none';
       }
     }
 

--- a/frontend/src/pages/Tournament/Waiting/index.ts
+++ b/frontend/src/pages/Tournament/Waiting/index.ts
@@ -55,7 +55,13 @@ const TournamentWaitingPage = new Page({
 
     // Connect to WebSocket
     // TODO: 実際のユーザー名を使用
-    const username = 'testuser';
+    const username = localStorage.getItem('username');
+    if (!username) {
+      showError('User is not logged in');
+      window.location.href = '/login';
+      return;
+    }
+    
     const wsUrl = `ws://${window.location.host}/ws/tournament/${tournamentId}/${username}/`;
     wsManager.connect(wsUrl);
 

--- a/frontend/src/pages/Tournament/Waiting/index.ts
+++ b/frontend/src/pages/Tournament/Waiting/index.ts
@@ -1,0 +1,102 @@
+// frontend/src/pages/Tournament/Waiting/index.ts
+import { Page } from '@/core/Page';
+import CommonLayout from '@/layouts/common/index';
+import { WebSocketManager, WebSocketMessage } from '@/core/WebSocketManager';
+
+interface TournamentState {
+  status: 'WAITING_PLAYERS' | 'IN_PROGRESS' | 'COMPLETED';
+  participants: string[];
+  current_round: number;
+  matches: any[];
+}
+
+const TournamentWaitingPage = new Page({
+  name: 'Tournament/Waiting',
+  config: {
+    layout: CommonLayout,
+  },
+  mounted: async ({ pg }) => {
+    const wsManager = new WebSocketManager();
+    const tournamentId = new URLSearchParams(window.location.search).get('id');
+    
+    if (!tournamentId) {
+      showError('Tournament ID is missing');
+      window.location.href = '/tournament';
+      return;
+    }
+
+    // Leave tournament button handler
+    const leaveButton = document.getElementById('leave-tournament');
+    if (leaveButton instanceof HTMLElement) {
+      leaveButton.addEventListener('click', () => {
+        wsManager.disconnect();
+        window.location.href = '/tournament';
+      });
+    }
+
+    // WebSocket event handlers
+    wsManager.on('connected', () => {
+      wsManager.send({ type: 'join_tournament' });
+    });
+
+    wsManager.on('tournament_state', (message: WebSocketMessage) => {
+      const state = message.state as TournamentState;
+      updateWaitingRoom(state);
+
+      // トーナメントが開始されたら試合ページへ遷移
+      if (state.status === 'IN_PROGRESS') {
+        window.location.href = `/tournament/game?id=${tournamentId}`;
+      }
+    });
+
+    wsManager.on('error', (message: string) => {
+      showError(message);
+    });
+
+    // Connect to WebSocket
+    // TODO: 実際のユーザー名を使用
+    const username = 'testuser';
+    const wsUrl = `ws://${window.location.host}/ws/tournament/${tournamentId}/${username}/`;
+    wsManager.connect(wsUrl);
+
+    // Cleanup
+    return () => {
+      wsManager.disconnect();
+    };
+
+    function updateWaitingRoom(state: TournamentState) {
+      // Update participant count
+      const countElement = document.getElementById('participant-count');
+      if (countElement) {
+        countElement.textContent = state.participants.length.toString();
+      }
+
+      // Update participant list
+      const listElement = document.getElementById('participant-list');
+      if (listElement) {
+        listElement.innerHTML = Array(4).fill(null).map((_, index) => {
+          const participant = state.participants[index];
+          return `
+            <div class="participant-slot ${participant ? '' : 'empty'}">
+              ${participant ? `
+                <div class="player-name">${participant}</div>
+                <div class="player-status">Ready</div>
+              ` : 'Waiting for player...'}
+            </div>
+          `;
+        }).join('');
+      }
+    }
+
+    function showError(message: string) {
+      const errorContainer = document.getElementById('error-container');
+      if (errorContainer) {
+        errorContainer.innerHTML = `
+          <div class="error-message">${message}</div>
+        `;
+      }
+    }
+  },
+});
+
+export default TournamentWaitingPage;

--- a/frontend/src/pages/Tournament/Waiting/index.ts
+++ b/frontend/src/pages/Tournament/Waiting/index.ts
@@ -23,13 +23,16 @@ const TournamentWaitingPage = new Page({
     if (joinButton instanceof HTMLElement) {
       joinButton.addEventListener('click', async () => {
         try {
-          const response = await fetch(`${API_URL}/api/tournaments/${tournamentId}/join/`, {
+          const response = await fetch(`${API_URL}/api/tournaments/${tournamentId}/`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
               'Authorization': `Token ${localStorage.getItem('token')}`,
             },
           });
+
+          console.log('Response status:', response.status);
+          console.log('response data:', response);
 
           if (!response.ok) {
             throw new Error('Failed to join tournament');

--- a/frontend/src/pages/Tournament/Waiting/index.ts
+++ b/frontend/src/pages/Tournament/Waiting/index.ts
@@ -124,6 +124,7 @@ const TournamentWaitingPage = new Page({
       window.removeEventListener('popstate', handleNavigation);
     };
 
+    // TODO: 参加者の取得が出来ていない???
     function updateWaitingRoom(state: TournamentState) {
       // Update participant count
       const countElement = document.getElementById('participant-count');
@@ -155,6 +156,7 @@ const TournamentWaitingPage = new Page({
       }
 
       // Update button visibility
+      // TODO: ここのisParticipantが正常に機能していない???
       const username = localStorage.getItem('username');
       const isParticipant = state.participants.includes(username);
       const joinButton = document.getElementById('join-tournament');

--- a/frontend/src/pages/Tournament/Waiting/index.ts
+++ b/frontend/src/pages/Tournament/Waiting/index.ts
@@ -11,7 +11,7 @@ const TournamentWaitingPage = new Page({
   mounted: async ({ pg }) => {
     const tournamentId = new URLSearchParams(window.location.search).get('id');
     let socket: WebSocket | null = null;
-    
+
     if (!tournamentId) {
       showError('Tournament ID is missing');
       window.location.href = '/tournament';
@@ -23,11 +23,11 @@ const TournamentWaitingPage = new Page({
     if (joinButton instanceof HTMLElement) {
       joinButton.addEventListener('click', async () => {
         try {
-          const response = await fetch(`${API_URL}/api/tournaments/${tournamentId}/`, {
+          const response = await fetch(`${API_URL}/api/tournaments/${tournamentId}/join/`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              'Authorization': `Token ${localStorage.getItem('token')}`,
+              Authorization: `Token ${localStorage.getItem('token')}`,
             },
           });
 
@@ -42,7 +42,6 @@ const TournamentWaitingPage = new Page({
           if (socket) {
             socket.send(JSON.stringify({ type: 'join_tournament' }));
           }
-
         } catch (error) {
           showError('Failed to join tournament');
         }
@@ -135,17 +134,24 @@ const TournamentWaitingPage = new Page({
       // Update participant list
       const listElement = document.getElementById('participant-list');
       if (listElement) {
-        listElement.innerHTML = Array(4).fill(null).map((_, index) => {
-          const participant = state.participants[index];
-          return `
+        listElement.innerHTML = Array(4)
+          .fill(null)
+          .map((_, index) => {
+            const participant = state.participants[index];
+            return `
             <div class="participant-slot ${participant ? '' : 'empty'}">
-              ${participant ? `
+              ${
+                participant
+                  ? `
                 <div class="player-name">${participant}</div>
                 <div class="player-status">Ready</div>
-              ` : 'Waiting for player...'}
+              `
+                  : 'Waiting for player...'
+              }
             </div>
           `;
-        }).join('');
+          })
+          .join('');
       }
 
       // Update button visibility
@@ -153,7 +159,7 @@ const TournamentWaitingPage = new Page({
       const isParticipant = state.participants.includes(username);
       const joinButton = document.getElementById('join-tournament');
       const leaveButton = document.getElementById('leave-tournament');
-      
+
       if (joinButton && leaveButton) {
         joinButton.style.display = isParticipant ? 'none' : 'inline-block';
         leaveButton.style.display = isParticipant ? 'inline-block' : 'none';

--- a/frontend/src/pages/Tournament/Waiting/style.css
+++ b/frontend/src/pages/Tournament/Waiting/style.css
@@ -1,0 +1,106 @@
+/* frontend/src/pages/Tournament/Waiting/style.css */
+.waiting-room-container {
+  max-width: 800px;
+  margin: 20px auto;
+  padding: 30px;
+  background-color: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.waiting-room-header {
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+.waiting-room-header h1 {
+  color: #1f2937;
+  font-size: 24px;
+  margin-bottom: 10px;
+}
+
+.waiting-status {
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+.participant-count {
+  display: inline-block;
+  background-color: #dbeafe;
+  color: #1e40af;
+  padding: 8px 16px;
+  border-radius: 20px;
+  font-weight: 500;
+}
+
+.participant-list {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  margin-bottom: 30px;
+}
+
+.participant-slot {
+  background-color: #f9fafb;
+  border: 2px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 16px;
+  min-height: 80px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.participant-slot.empty {
+  border-style: dashed;
+  color: #6b7280;
+}
+
+.participant-slot .player-name {
+  font-weight: 500;
+  color: #1f2937;
+  margin-bottom: 4px;
+}
+
+.participant-slot .player-status {
+  font-size: 14px;
+  color: #059669;
+}
+
+.waiting-room-info {
+  text-align: center;
+  padding: 20px;
+  background-color: #f9fafb;
+  border-radius: 8px;
+  margin-top: 20px;
+}
+
+.waiting-room-info p {
+  color: #6b7280;
+  margin-bottom: 15px;
+}
+
+.btn-secondary {
+  background-color: #ef4444;
+  color: white;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background-color 0.2s;
+}
+
+.btn-secondary:hover {
+  background-color: #dc2626;
+}
+
+.error-message {
+  background-color: #fee2e2;
+  border: 1px solid #ef4444;
+  color: #991b1b;
+  padding: 10px 15px;
+  margin: 10px 0;
+  border-radius: 4px;
+}

--- a/frontend/src/pages/Tournament/Waiting/style.css
+++ b/frontend/src/pages/Tournament/Waiting/style.css
@@ -81,6 +81,22 @@
   margin-bottom: 15px;
 }
 
+.btn-primary {
+  background-color: #3b82f6;  /* blue-500 */
+  color: white;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background-color 0.2s;
+  margin-right: 10px;  /* Leaveボタンとの間隔 */
+}
+
+.btn-primary:hover {
+  background-color: #2563eb;  /* blue-600 */
+}
+
 .btn-secondary {
   background-color: #ef4444;
   color: white;

--- a/frontend/src/pages/Tournament/index.html
+++ b/frontend/src/pages/Tournament/index.html
@@ -1,35 +1,14 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tournament Bracket</title>
-    <link rel="stylesheet" href="styles.css" />
-  </head>
-  <body>
-    <div class="tournament">
-      <div class="trophy">🏆</div>
-      <div class="round semi">
-        <div class="match">Winner</div>
-        <div class="match">Winner</div>
-      </div>
-      <div class="round quarter">
-        <div class="match">Winner</div>
-        <div class="match">Winner</div>
-        <div class="match">Winner</div>
-        <div class="match">Winner</div>
-      </div>
-      <div class="round eighth">
-        <div class="match">Player 1</div>
-        <div class="match">Player 2</div>
-        <div class="match">Player 3</div>
-        <div class="match">Player 4</div>
-        <div class="match">Player 5</div>
-        <div class="match">Player 6</div>
-        <div class="match">Player 7</div>
-        <div class="match">Player 8</div>
-      </div>
-      <button id="backBtn" class="btn">Back to Home</button>
-    </div>
-  </body>
-</html>
+<!-- frontend/src/pages/Tournament/index.html -->
+<div class="tournament-container">
+  <div class="tournament-header">
+    <h1>Tournament</h1>
+  </div>
+  
+  <!-- エラーメッセージ表示エリア -->
+  <div id="error-container"></div>
+  
+  <!-- メインコンテンツエリア -->
+  <div class="tournament-content">
+    <!-- 動的に内容が変更される -->
+  </div>
+</div>

--- a/frontend/src/pages/Tournament/index.html
+++ b/frontend/src/pages/Tournament/index.html
@@ -1,14 +1,21 @@
 <!-- frontend/src/pages/Tournament/index.html -->
 <div class="tournament-container">
   <div class="tournament-header">
-    <h1>Tournament</h1>
+    <h1>Tournaments</h1>
   </div>
   
   <!-- エラーメッセージ表示エリア -->
   <div id="error-container"></div>
+
+  <!-- トーナメント作成ボタン -->
+  <div class="tournament-actions">
+    <button id="create-tournament" class="btn-primary">Create New Tournament</button>
+  </div>
   
-  <!-- メインコンテンツエリア -->
+  <!-- トーナメント一覧 -->
   <div class="tournament-content">
-    <!-- 動的に内容が変更される -->
+    <div class="tournament-list">
+      <!-- トーナメントカードがここに動的に追加される -->
+    </div>
   </div>
 </div>

--- a/frontend/src/pages/Tournament/index.ts
+++ b/frontend/src/pages/Tournament/index.ts
@@ -1,19 +1,120 @@
+// frontend/src/pages/Tournament/index.ts
 import { Page } from '@/core/Page';
 import CommonLayout from '@/layouts/common/index';
-import { checkUserAccess } from '@/models/User/auth';
+import { WebSocketManager, WebSocketMessage } from '@/core/WebSocketManager';
+
+interface TournamentState {
+  status: 'WAITING_PLAYERS' | 'IN_PROGRESS' | 'COMPLETED';
+  current_round: number;
+  participants: string[];
+  matches: {
+    id: number;
+    round: number;
+    match_number: number;
+    player1: string | null;
+    player2: string | null;
+    winner: string | null;
+    scores: {
+      player1: number;
+      player2: number;
+    };
+  }[];
+}
 
 const TournamentPage = new Page({
   name: 'Tournament',
   config: {
     layout: CommonLayout,
   },
-  mounted: async () => {
-    checkUserAccess();
-    const backBtn = document.getElementById('backBtn');
+  mounted: async ({ pg }) => {
+    const wsManager = new WebSocketManager();
+    let tournamentState: TournamentState | null = null;
 
-    backBtn?.addEventListener('click', () => {
-      window.location.href = '/';
+    // WebSocket接続の設定
+    wsManager.on('connected', () => {
+      wsManager.send({ type: 'join_tournament' });
     });
+
+    wsManager.on('tournament_state', (message: WebSocketMessage) => {
+      tournamentState = message.state as TournamentState;
+      updateView();
+    });
+
+    wsManager.on('error', (message: string) => {
+      showError(message);
+    });
+
+    // WebSocket接続を開始
+    const wsUrl = `ws://${window.location.host}/ws/tournament/1/testuser/`; // TODO: IDとユーザー名を動的に
+    wsManager.connect(wsUrl);
+
+    // ビュー更新関数
+    function updateView() {
+      const mainElement = document.querySelector('main');
+      if (!mainElement || !tournamentState) return;
+
+      switch (tournamentState.status) {
+        case 'WAITING_PLAYERS':
+          mainElement.innerHTML = `
+            <div class="waiting-room">
+              <h2>Waiting Room</h2>
+              <p>Players (${tournamentState.participants.length}/4):</p>
+              <ul>
+                ${tournamentState.participants.map(player => `
+                  <li>${player}</li>
+                `).join('')}
+              </ul>
+            </div>
+          `;
+          break;
+
+        case 'IN_PROGRESS':
+          mainElement.innerHTML = `
+            <div class="tournament">
+              <h2>Tournament (Round ${tournamentState.current_round})</h2>
+              <div class="matches">
+                ${tournamentState.matches.map(match => `
+                  <div class="match">
+                    <div class="player">${match.player1 || 'TBD'}</div>
+                    <div class="vs">vs</div>
+                    <div class="player">${match.player2 || 'TBD'}</div>
+                    ${match.winner ? `<div class="winner">Winner: ${match.winner}</div>` : ''}
+                  </div>
+                `).join('')}
+              </div>
+            </div>
+          `;
+          break;
+
+        case 'COMPLETED':
+          const finalMatch = tournamentState.matches.find(m => m.round === 2);
+          if (finalMatch) {
+            mainElement.innerHTML = `
+              <div class="results">
+                <h2>Tournament Complete</h2>
+                <div class="winner-display">
+                  <h3>Winner</h3>
+                  <p>${finalMatch.winner}</p>
+                </div>
+              </div>
+            `;
+          }
+          break;
+      }
+    }
+
+    // エラー表示関数
+    function showError(message: string) {
+      const mainElement = document.querySelector('main');
+      if (!mainElement) return;
+
+      const errorElement = document.createElement('div');
+      errorElement.className = 'error-message';
+      errorElement.textContent = message;
+
+      mainElement.prepend(errorElement);
+      setTimeout(() => errorElement.remove(), 5000);
+    }
   },
 });
 

--- a/frontend/src/pages/Tournament/index.ts
+++ b/frontend/src/pages/Tournament/index.ts
@@ -4,14 +4,7 @@ import { Page } from '@/core/Page';
 import CommonLayout from '@/layouts/common/index';
 import { API_URL } from '@/config/config';
 import { WebSocketManager, WebSocketMessage } from '@/core/WebSocketManager';
-
-interface Tournament {
-  id: number;
-  name: string;
-  status: 'WAITING_PLAYERS' | 'IN_PROGRESS' | 'COMPLETED';
-  created_at: string;
-  participants: number;
-}
+import { Tournament } from '@/types/tournament';
 
 const TournamentPage = new Page({
   name: 'Tournament',
@@ -24,8 +17,8 @@ const TournamentPage = new Page({
       try {
         const response = await fetch(`${API_URL}/api/tournaments`, {
           headers: {
-            'Authorization': `Token ${localStorage.getItem('token')}`, // 認証トークンを追加
-          }
+            Authorization: `Token ${localStorage.getItem('token')}`, // 認証トークンを追加
+          },
         });
         if (!response.ok) throw new Error('Failed to fetch tournaments');
         const tournaments = await response.json();
@@ -40,7 +33,9 @@ const TournamentPage = new Page({
       const listElement = document.querySelector('.tournament-list');
       if (!listElement) return;
 
-      listElement.innerHTML = tournaments.map(tournament => `
+      listElement.innerHTML = tournaments
+        .map(
+          (tournament) => `
         <div class="tournament-card" data-id="${tournament.id}">
           <h3>${tournament.name}</h3>
           <span class="tournament-card-status status-${tournament.status.toLowerCase()}">
@@ -54,10 +49,12 @@ const TournamentPage = new Page({
             ${renderActionButton(tournament)}
           </div>
         </div>
-      `).join('');
+      `
+        )
+        .join('');
 
       // カードのクリックイベントを設定
-      listElement.querySelectorAll('.tournament-card').forEach(card => {
+      listElement.querySelectorAll('.tournament-card').forEach((card) => {
         card.addEventListener('click', (e) => {
           if (e.target instanceof HTMLButtonElement) return; // ボタンクリックは除外
           const id = card.getAttribute('data-id');
@@ -77,10 +74,14 @@ const TournamentPage = new Page({
     // 状態の表示形式を整形
     function formatStatus(status: string): string {
       switch (status) {
-        case 'WAITING_PLAYERS': return 'Waiting for Players';
-        case 'IN_PROGRESS': return 'In Progress';
-        case 'COMPLETED': return 'Completed';
-        default: return status;
+        case 'WAITING_PLAYERS':
+          return 'Waiting for Players';
+        case 'IN_PROGRESS':
+          return 'In Progress';
+        case 'COMPLETED':
+          return 'Completed';
+        default:
+          return status;
       }
     }
 
@@ -113,23 +114,23 @@ const TournamentPage = new Page({
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              'Authorization': `Token ${localStorage.getItem('token')}`, // 認証トークンを追加
+              Authorization: `Token ${localStorage.getItem('token')}`, // 認証トークンを追加
             },
             body: JSON.stringify({
-              name: `Tournament ${new Date().toLocaleString()}`
+              name: `Tournament ${new Date().toLocaleString()}`,
             }),
           });
-    
+
           if (!response.ok) {
             const errorText = await response.text();
             console.error('Tournament creation error:', {
               status: response.status,
               statusText: response.statusText,
-              errorBody: errorText
+              errorBody: errorText,
             });
             throw new Error(`Failed to create tournament: ${response.status} ${errorText}`);
           }
-          
+
           // 作成後、一覧を再取得
           fetchTournaments();
         } catch (error) {

--- a/frontend/src/pages/Tournament/index.ts
+++ b/frontend/src/pages/Tournament/index.ts
@@ -91,7 +91,7 @@ const TournamentPage = new Page({
 
     // トーナメントの詳細表示へ移動
     function viewTournament(id: string) {
-      window.location.href = `/tournament/${id}`;
+      window.location.href = `/tournament/waiting?id=${id}`;
     }
 
     // エラーメッセージの表示

--- a/frontend/src/pages/Tournament/style.css
+++ b/frontend/src/pages/Tournament/style.css
@@ -1,87 +1,143 @@
-body {
-  font-family: 'Arial', sans-serif;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
-  margin: 0;
-  color: #fff;
+/* frontend/src/pages/Tournament/style.css */
+
+.tournament-container {
+  max-width: 1200px;
+  margin: 20px auto;
+  padding: 30px;
+  background-color: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
+.tournament-header {
+  text-align: center;
+  margin-bottom: 30px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.tournament-header h1 {
+  color: #1f2937;
+  font-size: 24px;
+  font-weight: bold;
+}
+
+.tournament-content {
+  min-height: 400px;
+  background-color: #ffffff;
+  padding: 20px;
+}
+
+/* エラーメッセージ */
+.error-message {
+  background-color: #fee2e2;
+  border: 1px solid #ef4444;
+  color: #991b1b;
+  padding: 10px 15px;
+  margin-bottom: 20px;
+  border-radius: 4px;
+}
+
+/* 待機室 */
+.waiting-room {
+  background-color: #f9fafb;
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 20px;
+}
+
+.waiting-room h2 {
+  color: #1f2937;
+  margin-bottom: 15px;
+}
+
+.waiting-room ul {
+  list-style: none;
+  padding: 0;
+}
+
+.waiting-room li {
+  padding: 10px;
+  margin: 5px 0;
+  background-color: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+}
+
+/* トーナメント */
 .tournament {
+  padding: 20px;
+}
+
+.tournament h2 {
+  color: #1f2937;
+  margin-bottom: 20px;
+}
+
+.matches {
   display: flex;
   flex-direction: column;
-  align-items: center;
-}
-
-.trophy {
-  font-size: 64px;
-  color: #ffdf00;
-  margin-bottom: 20px;
-  text-shadow:
-    0 0 10px #ffdf00,
-    0 0 20px #ffaa00;
-}
-
-.round {
-  display: flex;
-  justify-content: center;
-  margin: 20px 0;
   gap: 20px;
 }
 
 .match {
-  width: 120px;
-  height: 60px;
-  border: 2px solid #00ffcc;
-  margin: 10px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
   border-radius: 8px;
-  box-shadow:
-    0 0 10px #00ffcc,
-    0 0 20px #00ffaa;
-  font-size: 16px;
+  padding: 15px;
+  margin: 10px 0;
+}
+
+.player {
+  padding: 10px;
+  margin: 5px 0;
+  background-color: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  color: #1f2937;
+}
+
+.vs {
+  text-align: center;
+  padding: 5px;
+  color: #6b7280;
   font-weight: bold;
-  color: #fff;
-  text-transform: uppercase;
-  transition:
-    transform 0.3s,
-    box-shadow 0.3s;
 }
 
-.match:hover {
-  transform: scale(1.1);
-  box-shadow:
-    0 0 15px #00ffaa,
-    0 0 30px #00ffcc;
-}
-
-.semi .match {
-  width: 160px;
-  margin: 0 230px;
-}
-
-.quarter .match {
-  width: 160px;
-  margin: 0 70px;
-}
-
-.btn {
-  padding: 12px 25px;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-  transition: 0.3s;
-  color: #fff;
-  background-color: #007bff;
-  font-size: 1rem;
+.winner {
+  margin-top: 10px;
+  padding: 8px;
+  background-color: #ecfdf5;
+  color: #047857;
+  border-radius: 4px;
+  text-align: center;
   font-weight: bold;
-  margin-top: 20px;
 }
 
-.btn:hover {
-  background-color: #0056b3;
+/* 結果表示 */
+.results {
+  text-align: center;
+  padding: 40px 20px;
+}
+
+.winner-display {
+  margin-top: 30px;
+  padding: 20px;
+  background-color: #ecfdf5;
+  border-radius: 8px;
+  border: 1px solid #047857;
+}
+
+.winner-display h3 {
+  color: #047857;
+  margin-bottom: 10px;
+  font-weight: bold;
+}
+
+/* レスポンシブ対応 */
+@media (max-width: 768px) {
+  .tournament-container {
+    margin: 10px;
+    padding: 15px;
+  }
 }

--- a/frontend/src/pages/Tournament/style.css
+++ b/frontend/src/pages/Tournament/style.css
@@ -141,3 +141,80 @@
     padding: 15px;
   }
 }
+
+.tournament-actions {
+  margin-bottom: 20px;
+  text-align: right;
+}
+
+.btn-primary {
+  background-color: #3b82f6;
+  color: white;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.btn-primary:hover {
+  background-color: #2563eb;
+}
+
+.tournament-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 20px;
+  padding: 20px 0;
+}
+
+.tournament-card {
+  background-color: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 16px;
+  transition: transform 0.2s;
+}
+
+.tournament-card:hover {
+  transform: translateY(-2px);
+}
+
+.tournament-card h3 {
+  color: #1f2937;
+  margin-bottom: 8px;
+  font-size: 18px;
+}
+
+.tournament-card-status {
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 14px;
+  margin-bottom: 12px;
+}
+
+.status-waiting {
+  background-color: #dbeafe;
+  color: #1e40af;
+}
+
+.status-in-progress {
+  background-color: #fef3c7;
+  color: #92400e;
+}
+
+.status-completed {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.tournament-card-info {
+  font-size: 14px;
+  color: #4b5563;
+  margin-bottom: 16px;
+}
+
+.tournament-card-actions {
+  text-align: right;
+}

--- a/frontend/src/types/tournament.d.ts
+++ b/frontend/src/types/tournament.d.ts
@@ -1,0 +1,21 @@
+// frontend/src/types/tournament.d.ts
+
+export interface TournamentMatch {
+    id: number;
+    round: number;
+    match_number: number;
+    player1: string | null;
+    player2: string | null;
+    winner: string | null;
+    scores: {
+      player1: number;
+      player2: number;
+    };
+  }
+  
+  export interface TournamentState {
+    status: 'WAITING_PLAYERS' | 'IN_PROGRESS' | 'COMPLETED';
+    current_round: number;
+    participants: string[];
+    matches: TournamentMatch[];
+  }

--- a/frontend/src/types/tournament.d.ts
+++ b/frontend/src/types/tournament.d.ts
@@ -5,7 +5,7 @@ export interface Tournament {
   name: string;
   status: 'WAITING_PLAYERS' | 'IN_PROGRESS' | 'COMPLETED';
   created_at: string;
-  participants: number;
+  participants: string[];
 }
 
 export interface TournamentMatch {

--- a/frontend/src/types/tournament.d.ts
+++ b/frontend/src/types/tournament.d.ts
@@ -1,21 +1,29 @@
 // frontend/src/types/tournament.d.ts
 
+export interface Tournament {
+  id: number;
+  name: string;
+  status: 'WAITING_PLAYERS' | 'IN_PROGRESS' | 'COMPLETED';
+  created_at: string;
+  participants: number;
+}
+
 export interface TournamentMatch {
-    id: number;
-    round: number;
-    match_number: number;
-    player1: string | null;
-    player2: string | null;
-    winner: string | null;
-    scores: {
-      player1: number;
-      player2: number;
-    };
-  }
-  
-  export interface TournamentState {
-    status: 'WAITING_PLAYERS' | 'IN_PROGRESS' | 'COMPLETED';
-    current_round: number;
-    participants: string[];
-    matches: TournamentMatch[];
-  }
+  id: number;
+  round: number;
+  match_number: number;
+  player1: string | null;
+  player2: string | null;
+  winner: string | null;
+  scores: {
+    player1: number;
+    player2: number;
+  };
+}
+
+export interface TournamentState {
+  status: 'WAITING_PLAYERS' | 'IN_PROGRESS' | 'COMPLETED';
+  current_round: number;
+  participants: string[];
+  matches: TournamentMatch[];
+}


### PR DESCRIPTION
## 概要
トーナメント機能のフロントエンド全部やります
## 新規追加

### pages/Tournament/
以下参考。追加もある
- Matching/: プレイヤー募集待機画面（既存Waitingを参考に）
- Game/: 実際の対戦画面（既存MultiPlay/Gameを流用）
- StandBy/: 他の対戦待ち画面
- Result/: トーナメント結果画面
- components/TournamentBracket/: トーナメント表示用コンポーネント

## 修正
- pages/GameModes/: トーナメントモード選択の追加
- models/User/repository.ts: トーナメント関連APIの追加

## テスト
TODO:

## 関連Issue
- 関連Issue: #155 #157
