### PR TITLE
Hrinka2/add game logic#211

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,0 +1,4 @@
+export ZSH="$HOME/.oh-my-zsh"
+ZSH_THEME=dpoggi
+plugins=(git zsh-autosuggestions zsh-syntax-highlighting)
+source "$ZSH/oh-my-zsh.sh"

--- a/frontend/src/pages/SinglePlay/Game/Ball.ts
+++ b/frontend/src/pages/SinglePlay/Game/Ball.ts
@@ -3,11 +3,11 @@ import * as THREE from 'three';
 import Experience from './Experience'; // 実際のパスに合わせて修正してください
 
 export default class Ball {
-  private experience: Experience
-  private scene: THREE.Scene
-  private camera: THREE.PerspectiveCamera
-  private BALL_RADIUS: number
-  private FIELD_LENGTH: number
+  private experience: Experience;
+  private scene: THREE.Scene;
+  private camera: THREE.PerspectiveCamera;
+  private BALL_RADIUS: number;
+  private FIELD_LENGTH: number;
 
   public ballGeometry!: THREE.SphereGeometry;
   public ballMaterial!: THREE.MeshNormalMaterial;
@@ -43,7 +43,7 @@ export default class Ball {
     this.camera.lookAt(this.ball.position);
 
     // ボールの初期座標をセット
-    this.ball.position.set(0, 0, 0)
+    this.ball.position.set(0, 0, 0);
     console.log('Ball position after set:', this.ball.position);
   }
 

--- a/frontend/src/pages/SinglePlay/Game/Experience.ts
+++ b/frontend/src/pages/SinglePlay/Game/Experience.ts
@@ -76,8 +76,6 @@ export default class Experience {
     this.localGame = new LocalGame(canvas);
     this.localGameStarted = true;
     this.sizes.on('resize', () => this.resize());
-    this.time.on('tick', () => this.update());
-
     this.resize();
   }
 
@@ -104,7 +102,7 @@ export default class Experience {
     }
     this.cameraClass.update();
     this.renderer.update();
-    requestAnimationFrame(() => this.update());
+    // requestAnimationFrame(() => this.update());
     console.log("Experience update running");
   }
 

--- a/frontend/src/pages/SinglePlay/Game/Experience.ts
+++ b/frontend/src/pages/SinglePlay/Game/Experience.ts
@@ -104,7 +104,7 @@ export default class Experience {
     this.renderer.update();
     this.field.updateParticles();
     // requestAnimationFrame(() => this.update());
-    console.log("Experience update running");
+    console.log('Experience update running');
   }
 
   public destroy(): void {

--- a/frontend/src/pages/SinglePlay/Game/Experience.ts
+++ b/frontend/src/pages/SinglePlay/Game/Experience.ts
@@ -102,6 +102,7 @@ export default class Experience {
     }
     this.cameraClass.update();
     this.renderer.update();
+    this.field.updateParticles();
     // requestAnimationFrame(() => this.update());
     console.log("Experience update running");
   }

--- a/frontend/src/pages/SinglePlay/Game/Experience.ts
+++ b/frontend/src/pages/SinglePlay/Game/Experience.ts
@@ -30,7 +30,7 @@ export default class Experience {
   public NEAR: number = 0.1;
   public FAR: number = 5000;
   public FIELD_WIDTH: number = 1500;
-  public FIELD_LENGTH: number = 2400;
+  public FIELD_LENGTH: number = 2600;
   public BALL_RADIUS: number = 20;
   public PADDLE_WIDTH: number = 150;
   public PADDLE_HEIGHT: number = 30;

--- a/frontend/src/pages/SinglePlay/Game/Experience.ts
+++ b/frontend/src/pages/SinglePlay/Game/Experience.ts
@@ -96,7 +96,6 @@ export default class Experience {
 
   public update(): void {
     this.world.update();
-    // this.cameraLerp.update();
     this.ball.update();
     this.field.update();
     this.paddle.update();
@@ -105,6 +104,8 @@ export default class Experience {
     }
     this.cameraClass.update();
     this.renderer.update();
+    requestAnimationFrame(() => this.update());
+    console.log("Experience update running");
   }
 
   public destroy(): void {
@@ -123,6 +124,6 @@ export default class Experience {
     });
   }
   public initializeRenderer(canvas: HTMLCanvasElement): void {
-    this.renderer = new Renderer(canvas); // カスタムクラスをnew
+    this.renderer = new Renderer(canvas);
   }
 }

--- a/frontend/src/pages/SinglePlay/Game/Field.ts
+++ b/frontend/src/pages/SinglePlay/Game/Field.ts
@@ -8,6 +8,9 @@ export default class Field {
   private scene: THREE.Scene;
   private FIELD_WIDTH: number;
   private FIELD_LENGTH: number;
+  private particleSystem: THREE.Points;
+  private particlePositions: Float32Array;
+  private particleSpeeds: Float32Array;
 
   private fieldGeometry!: THREE.BoxGeometry;
   private fieldMaterial!: THREE.MeshNormalMaterial;
@@ -23,10 +26,10 @@ export default class Field {
     this.FIELD_LENGTH = this.experience.FIELD_LENGTH;
 
     this.setField();
+    this.setBackgroundParticles(); // 追加：背景のパーティクルをセット
   }
 
   private setField() {
-    // BoxGeometry(幅, 高さ, 奥行き, 幅方向の分割数, 高さ方向の分割数, 奥行き方向の分割数)
     this.fieldGeometry = new THREE.BoxGeometry(
       this.FIELD_WIDTH,
       1500,
@@ -35,21 +38,7 @@ export default class Field {
       20,
       20
     );
-
-
-    // // 卓球の平台のジオメトリを作成
-    // this.fieldGeometry2 = new THREE.BoxGeometry(1500, 10, this.FIELD_LENGTH);
-
-    // // ワイヤーフレームのマテリアルを作成
-    // this.fieldMaterial2 = new THREE.MeshNormalMaterial({
-    //   wireframe: true,
-    //   transparent: true,
-    //   opacity: 0.5,
-    // });
-
-    // this.fieldGeometry = new THREE.BoxGeometry(900, 10, 3000)
-    this.fieldMaterial = new THREE.MeshNormalMaterial({
-      // color: 0x000aff,
+      this.fieldMaterial = new THREE.MeshNormalMaterial({
       wireframe: true,
       transparent: true,
       opacity: 0.5,
@@ -62,9 +51,50 @@ export default class Field {
 
     this.scene.add(this.field);
     console.log('Field added to scene:', this.field);
+    this.setBackgroundParticles();
+  }
+  
+  private setBackgroundParticles(): void {
+    const particleCount = 7000;
+    const particlesGeometry = new THREE.BufferGeometry();
+    this.particlePositions = new Float32Array(particleCount * 3);
+    this.particleSpeeds = new Float32Array(particleCount * 3);
+
+    // 広めの空間にランダムな座標を設定（例：-5000～+5000 の範囲）
+    for (let i = 0; i < particleCount * 3; i++) {
+      this.particlePositions[i] = (Math.random() - 0.5) * 10000;
+      this.particleSpeeds[i] = (Math.random() - 0.5) * 0.1; // パーティクルの速度を設定
+    }
+    particlesGeometry.setAttribute('position', new THREE.BufferAttribute(this.particlePositions, 3));
+
+    // PointsMaterial で星のようなパーティクルを作成
+    const particlesMaterial = new THREE.PointsMaterial({
+      color: 0xffffff,
+      size: 5,
+      transparent: true,
+      opacity: 0.8,
+      depthWrite: false,
+    });
+
+    this.particleSystem = new THREE.Points(particlesGeometry, particlesMaterial);
+    this.scene.add(this.particleSystem);
+    console.log('Background particles added');
   }
 
-  // 毎フレーム呼び出される更新メソッドが必要なら
+  public updateParticles(): void {
+    const positions = this.particleSystem.geometry.attributes.position.array as Float32Array;
+    for (let i = 0; i < positions.length; i += 3) {
+      positions[i] += this.particleSpeeds[i]; // x 方向に速度を適用
+      positions[i + 1] += this.particleSpeeds[i + 1]; // y 方向に速度を適用
+      positions[i + 2] += this.particleSpeeds[i + 2]; // z 方向に速度を適用
+
+      if (positions[i] > 5000 || positions[i] < -5000) this.particleSpeeds[i] *= -1;
+      if (positions[i + 1] > 5000 || positions[i + 1] < -5000) this.particleSpeeds[i + 1] *= -1;
+      if (positions[i + 2] > 5000 || positions[i + 2] < -5000) this.particleSpeeds[i + 2] *= -1;
+    }
+    this.particleSystem.geometry.attributes.position.needsUpdate = true;
+  }
+
   public update() {
     // 必要に応じて実装
   }

--- a/frontend/src/pages/SinglePlay/Game/Field.ts
+++ b/frontend/src/pages/SinglePlay/Game/Field.ts
@@ -38,7 +38,7 @@ export default class Field {
       20,
       20
     );
-      this.fieldMaterial = new THREE.MeshNormalMaterial({
+    this.fieldMaterial = new THREE.MeshNormalMaterial({
       wireframe: true,
       transparent: true,
       opacity: 0.5,
@@ -53,7 +53,7 @@ export default class Field {
     console.log('Field added to scene:', this.field);
     this.setBackgroundParticles();
   }
-  
+
   private setBackgroundParticles(): void {
     const particleCount = 7000;
     const particlesGeometry = new THREE.BufferGeometry();
@@ -65,7 +65,10 @@ export default class Field {
       this.particlePositions[i] = (Math.random() - 0.5) * 10000;
       this.particleSpeeds[i] = (Math.random() - 0.5) * 0.1; // パーティクルの速度を設定
     }
-    particlesGeometry.setAttribute('position', new THREE.BufferAttribute(this.particlePositions, 3));
+    particlesGeometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(this.particlePositions, 3)
+    );
 
     // PointsMaterial で星のようなパーティクルを作成
     const particlesMaterial = new THREE.PointsMaterial({

--- a/frontend/src/pages/SinglePlay/Game/LocalGame.ts
+++ b/frontend/src/pages/SinglePlay/Game/LocalGame.ts
@@ -28,18 +28,19 @@ export default class LocalGame {
     this.time = new THREE.Clock();
     this.scene = this.experience.scene;
     this.camera = this.experience.camera as unknown as THREE.PerspectiveCamera;
-    this.field = this.experience.field as unknown as THREE.Mesh; // Assuming 'field' is of type THREE.Mesh
+    this.field = this.experience.field as unknown as THREE.Mesh; 
     this.ball = this.experience.ball.ball;
     this.ballMaterial = this.experience.ball.ballMaterial;
     this.paddleTwo = this.experience.paddle.paddleTwo;
     this.paddleOne = this.experience.paddle.paddleOne;
 
+    this.startBallMovement();
     this.handleKeyboard();
   }
 
   private startBallMovement() {
     const direction = Math.random() > 0.5 ? -1 : 1;
-    this.ballVelocity = { x: 0, z: direction * 0.2 };
+    this.ballVelocity = { x: 0, z: direction * 0.4 };//ボールの速度調整
     this.ballStopped = false;
   }
 
@@ -57,7 +58,9 @@ export default class LocalGame {
     this.ball.position.x += this.ballVelocity?.x ?? 0;
     this.ball.position.z += this.ballVelocity?.z ?? 0;
 
-    if (this.isSideCollision()) this.ballVelocity?.x ?? 0;
+    if (this.isSideCollision()) {
+      this.ballVelocity!.x *= -1; // 壁に当たったらボールのX方向を反転
+    }    
     if (this.isPaddleCollision(this.paddleOne)) this.hitBallBack(this.paddleOne);
     if (this.isPaddleCollision(this.paddleTwo)) this.hitBallBack(this.paddleTwo);
     if (this.isPastPaddle(this.paddleOne)) this.scored('paddleTwo');
@@ -75,8 +78,10 @@ export default class LocalGame {
   }
 
   private isPaddleCollision(paddle: THREE.Mesh): boolean {
-    return Math.abs(this.ball.position.z - paddle.position.z) < 10;
-  }
+    const hitX = Math.abs(this.ball.position.x - paddle.position.x) < 75; // パドル幅考慮
+    const hitZ = Math.abs(this.ball.position.z - paddle.position.z) < 10;
+    return hitX && hitZ;
+  }  
 
   private hitBallBack(paddle: THREE.Mesh) {
     if (this.ballVelocity) {
@@ -88,10 +93,30 @@ export default class LocalGame {
   private scored(player: string) {
     this.stopBall();
     gsap.to(this.ballMaterial, { opacity: 0, duration: 0.5 });
+
     setTimeout(() => this.reset(), 600);
-    if (player === 'paddleOne') this.scorePaddleOne++;
-    else this.scorePaddleTwo++;
-  }
+
+    if (player === 'paddleOne') {
+        this.scorePaddleOne++;
+        if (this.scorePaddleOne >= 15) {
+            alert("You Win!");
+            this.restartGame();
+        }
+    } else {
+        this.scorePaddleTwo++;
+        if (this.scorePaddleTwo >= 15) {
+            alert("CPU Wins!");
+            this.restartGame();
+        }
+    }
+}
+
+private restartGame() {
+    this.scorePaddleOne = 0;
+    this.scorePaddleTwo = 0;
+    this.reset();
+}
+
 
   private stopBall() {
     this.ballStopped = true;
@@ -101,6 +126,7 @@ export default class LocalGame {
     this.ball.position.set(0, 0, 0);
     gsap.to(this.ballMaterial, { opacity: 1, duration: 0.5 });
     this.ballVelocity = null;
+    this.ballStopped = false;
   }
 
   private handleKeyboard() {
@@ -114,18 +140,31 @@ export default class LocalGame {
     });
   }
 
-  private processPlayerPaddle() {
+  // private processPlayerPaddle() {
+  //   if (this.leftKeyPressed && this.paddleOne.position.x > -450) {
+  //       this.paddleOne.position.x -= 10;  
+  //   }
+  //   if (this.rightKeyPressed && this.paddleOne.position.x < 450) {
+  //       this.paddleOne.position.x += 10; 
+  //   }
+  // }
+  private processPlayerPaddle(deltaTime: number) {
+    const paddleSpeed = 500; // 1秒間に動くピクセル量
+
     if (this.leftKeyPressed && this.paddleOne.position.x > -450) {
-        this.paddleOne.position.x -= 10;  
+        this.paddleOne.position.x -= paddleSpeed * deltaTime;
     }
     if (this.rightKeyPressed && this.paddleOne.position.x < 450) {
-        this.paddleOne.position.x += 10; 
+        this.paddleOne.position.x += paddleSpeed * deltaTime;
     }
-  }
+    
+}
+
 
   update() {
+    const deltaTime = this.time.getDelta(); 
     this.processBallMovement();
     this.processCpuPaddle();
-    this.processPlayerPaddle(); 
+    this.processPlayerPaddle(deltaTime); 
   }
 }

--- a/frontend/src/pages/SinglePlay/Game/LocalGame.ts
+++ b/frontend/src/pages/SinglePlay/Game/LocalGame.ts
@@ -1,7 +1,7 @@
 import gsap from 'gsap';
 import Experience from './Experience';
 import * as THREE from 'three';
-let running = true;
+const running = true;
 
 export default class LocalGame {
   private experience: Experience;
@@ -29,19 +29,20 @@ export default class LocalGame {
     this.time = new THREE.Clock();
     this.scene = this.experience.scene;
     this.camera = this.experience.camera as unknown as THREE.PerspectiveCamera;
-    this.field = this.experience.field as unknown as THREE.Mesh; 
+    this.field = this.experience.field as unknown as THREE.Mesh;
     this.ball = this.experience.ball.ball;
     this.ballMaterial = this.experience.ball.ballMaterial;
     this.paddleTwo = this.experience.paddle.paddleTwo;
     this.paddleOne = this.experience.paddle.paddleOne;
 
     this.startBallMovement();
-    this.handleKeyboard();5
+    this.handleKeyboard();
+    5;
   }
 
   private startBallMovement() {
     const direction = Math.random() > 0.5 ? -1 : 1;
-    this.ballVelocity = { x: 0, z: direction * 10.0 };//ボールの速度調整
+    this.ballVelocity = { x: 0, z: direction * 10.0 }; //ボールの速度調整
     this.ballStopped = false;
   }
 
@@ -61,7 +62,7 @@ export default class LocalGame {
 
     if (this.isSideCollision()) {
       this.ballVelocity!.x *= -1; // 壁に当たったらボールのX方向を反転
-    }    
+    }
     if (this.isPaddleCollision(this.paddleOne)) this.hitBallBack(this.paddleOne);
     if (this.isPaddleCollision(this.paddleTwo)) this.hitBallBack(this.paddleTwo);
     if (this.isPastPaddle(this.paddleOne)) this.scored('paddleTwo');
@@ -78,12 +79,11 @@ export default class LocalGame {
     return Math.abs(this.ball.position.x) > this.experience.FIELD_WIDTH / 2;
   }
 
-
   private isPaddleCollision(paddle: THREE.Mesh): boolean {
     const hitX = Math.abs(this.ball.position.x - paddle.position.x) < 75; // パドル幅考慮
     const hitZ = Math.abs(this.ball.position.z - paddle.position.z) < 10;
     return hitX && hitZ;
-  }  
+  }
 
   private hitBallBack(paddle: THREE.Mesh) {
     if (this.ballVelocity) {
@@ -102,28 +102,27 @@ export default class LocalGame {
     }, 600);
 
     if (player === 'paddleOne') {
-        this.scorePaddleOne++;
-        if (this.scorePaddleOne >= 5) {
-            alert("You Win!");
-            this.restartGame();
-        }
+      this.scorePaddleOne++;
+      if (this.scorePaddleOne >= 5) {
+        alert('You Win!');
+        this.restartGame();
+      }
     } else {
-        this.scorePaddleTwo++;
-        if (this.scorePaddleTwo >= 5) {
-            alert("CPU Wins!");
-            this.restartGame();
-        }
+      this.scorePaddleTwo++;
+      if (this.scorePaddleTwo >= 5) {
+        alert('CPU Wins!');
+        this.restartGame();
+      }
     }
     this.updateScoreDisplay();
   }
 
   private restartGame() {
-      this.scorePaddleOne = 0;
-      this.scorePaddleTwo = 0;
-      this.reset();
-      this.updateScoreDisplay();
+    this.scorePaddleOne = 0;
+    this.scorePaddleTwo = 0;
+    this.reset();
+    this.updateScoreDisplay();
   }
-
 
   private stopBall() {
     this.ballStopped = true;
@@ -151,19 +150,18 @@ export default class LocalGame {
     const paddleSpeed = 500; // 1秒間に動くピクセル量
 
     if (this.leftKeyPressed && this.paddleOne.position.x > -450) {
-        this.paddleOne.position.x -= paddleSpeed * deltaTime;
+      this.paddleOne.position.x -= paddleSpeed * deltaTime;
     }
     if (this.rightKeyPressed && this.paddleOne.position.x < 450) {
-        this.paddleOne.position.x += paddleSpeed * deltaTime;
+      this.paddleOne.position.x += paddleSpeed * deltaTime;
     }
-    
   }
 
   private updateScoreDisplay() {
     const playerNameElem = document.getElementById('playerName');
     const scoreElem = document.getElementById('score');
     const username = localStorage.getItem('username') || 'Player';
-  
+
     if (playerNameElem) {
       const leftNameSpan = playerNameElem.querySelector('.leftName');
       if (leftNameSpan) {
@@ -174,13 +172,12 @@ export default class LocalGame {
       scoreElem.textContent = `${this.scorePaddleOne} - ${this.scorePaddleTwo}`;
     }
   }
-  
 
   update() {
-    if (!running) return; 
-    const deltaTime = this.time.getDelta(); 
+    if (!running) return;
+    const deltaTime = this.time.getDelta();
     this.processBallMovement();
     this.processCpuPaddle();
-    this.processPlayerPaddle(deltaTime); 
+    this.processPlayerPaddle(deltaTime);
   }
 }

--- a/frontend/src/pages/SinglePlay/Game/LocalGame.ts
+++ b/frontend/src/pages/SinglePlay/Game/LocalGame.ts
@@ -75,8 +75,9 @@ export default class LocalGame {
   }
 
   private isSideCollision(): boolean {
-    return Math.abs(this.ball.position.x) > 450;
+    return Math.abs(this.ball.position.x) > this.experience.FIELD_WIDTH / 2;
   }
+
 
   private isPaddleCollision(paddle: THREE.Mesh): boolean {
     const hitX = Math.abs(this.ball.position.x - paddle.position.x) < 75; // パドル幅考慮
@@ -95,28 +96,33 @@ export default class LocalGame {
     this.stopBall();
     gsap.to(this.ballMaterial, { opacity: 0, duration: 0.5 });
 
-    setTimeout(() => this.reset(), 600);
+    setTimeout(() => {
+      this.reset();
+      this.updateScoreDisplay();
+    }, 600);
 
     if (player === 'paddleOne') {
         this.scorePaddleOne++;
-        if (this.scorePaddleOne >= 15) {
+        if (this.scorePaddleOne >= 5) {
             alert("You Win!");
             this.restartGame();
         }
     } else {
         this.scorePaddleTwo++;
-        if (this.scorePaddleTwo >= 15) {
+        if (this.scorePaddleTwo >= 5) {
             alert("CPU Wins!");
             this.restartGame();
         }
     }
-}
+    this.updateScoreDisplay();
+  }
 
-private restartGame() {
-    this.scorePaddleOne = 0;
-    this.scorePaddleTwo = 0;
-    this.reset();
-}
+  private restartGame() {
+      this.scorePaddleOne = 0;
+      this.scorePaddleTwo = 0;
+      this.reset();
+      this.updateScoreDisplay();
+  }
 
 
   private stopBall() {
@@ -128,6 +134,7 @@ private restartGame() {
     gsap.to(this.ballMaterial, { opacity: 1, duration: 0.5 });
     this.ballVelocity = null;
     this.ballStopped = false;
+    this.updateScoreDisplay();
   }
 
   private handleKeyboard() {
@@ -150,7 +157,24 @@ private restartGame() {
         this.paddleOne.position.x += paddleSpeed * deltaTime;
     }
     
-}
+  }
+
+  private updateScoreDisplay() {
+    const playerNameElem = document.getElementById('playerName');
+    const scoreElem = document.getElementById('score');
+    const username = localStorage.getItem('username') || 'Player';
+  
+    if (playerNameElem) {
+      const leftNameSpan = playerNameElem.querySelector('.leftName');
+      if (leftNameSpan) {
+        leftNameSpan.textContent = username;
+      }
+    }
+    if (scoreElem) {
+      scoreElem.textContent = `${this.scorePaddleOne} - ${this.scorePaddleTwo}`;
+    }
+  }
+  
 
   update() {
     if (!running) return; 

--- a/frontend/src/pages/SinglePlay/Game/LocalGame.ts
+++ b/frontend/src/pages/SinglePlay/Game/LocalGame.ts
@@ -1,6 +1,7 @@
 import gsap from 'gsap';
 import Experience from './Experience';
 import * as THREE from 'three';
+let running = true;
 
 export default class LocalGame {
   private experience: Experience;
@@ -35,12 +36,12 @@ export default class LocalGame {
     this.paddleOne = this.experience.paddle.paddleOne;
 
     this.startBallMovement();
-    this.handleKeyboard();
+    this.handleKeyboard();5
   }
 
   private startBallMovement() {
     const direction = Math.random() > 0.5 ? -1 : 1;
-    this.ballVelocity = { x: 0, z: direction * 0.4 };//ボールの速度調整
+    this.ballVelocity = { x: 0, z: direction * 10.0 };//ボールの速度調整
     this.ballStopped = false;
   }
 
@@ -139,15 +140,6 @@ private restartGame() {
       if (e.key === 'ArrowLeft') this.leftKeyPressed = false;
     });
   }
-
-  // private processPlayerPaddle() {
-  //   if (this.leftKeyPressed && this.paddleOne.position.x > -450) {
-  //       this.paddleOne.position.x -= 10;  
-  //   }
-  //   if (this.rightKeyPressed && this.paddleOne.position.x < 450) {
-  //       this.paddleOne.position.x += 10; 
-  //   }
-  // }
   private processPlayerPaddle(deltaTime: number) {
     const paddleSpeed = 500; // 1秒間に動くピクセル量
 
@@ -160,8 +152,8 @@ private restartGame() {
     
 }
 
-
   update() {
+    if (!running) return; 
     const deltaTime = this.time.getDelta(); 
     this.processBallMovement();
     this.processCpuPaddle();

--- a/frontend/src/pages/SinglePlay/Game/Paddle.ts
+++ b/frontend/src/pages/SinglePlay/Game/Paddle.ts
@@ -37,8 +37,8 @@ export default class Paddle {
   }
 
   private setPaddlePositions(): void {
-    this.paddleOne.position.set(0, 15, 1000);
-    this.paddleTwo.position.set(0, 15, -1000);
+    this.paddleOne.position.set(0, 15, 900);
+    this.paddleTwo.position.set(0, 15, -900);
   }
 
   public update(): void {}

--- a/frontend/src/pages/SinglePlay/Game/Wall.ts
+++ b/frontend/src/pages/SinglePlay/Game/Wall.ts
@@ -20,7 +20,7 @@ export default class Walls {
     this.FIELD_WIDTH = this.experience.FIELD_WIDTH;
     this.FIELD_LENGTH = this.experience.FIELD_LENGTH;
 
-    this.wallGeometry = new THREE.BoxGeometry(10, 20,this.experience.FIELD_LENGTH);
+    this.wallGeometry = new THREE.BoxGeometry(10, 20, this.experience.FIELD_LENGTH);
     this.wallMaterial = new THREE.MeshNormalMaterial({
       wireframe: true,
       transparent: true,

--- a/frontend/src/pages/SinglePlay/Game/Wall.ts
+++ b/frontend/src/pages/SinglePlay/Game/Wall.ts
@@ -27,8 +27,8 @@ export default class Walls {
       opacity: 0.5,
     });
 
-    this.wallRight = this.createWall(this.experience.FIELD_WIDTH / 2 + 5, 100, 0); // wallRight プロパティを初期化
-    this.wallLeft = this.createWall(-this.experience.FIELD_WIDTH / 2 - 5, 100, 0); // wallLeft プロパティを初期化
+    this.wallRight = this.createWall(this.experience.FIELD_WIDTH / 2 + 5, 0, 0); // wallRight プロパティを初期化
+    this.wallLeft = this.createWall(-this.experience.FIELD_WIDTH / 2 - 5, 0, 0); // wallLeft プロパティを初期化
 
     this.setWallsRight();
     this.setWallsLeft();

--- a/frontend/src/pages/SinglePlay/Game/Wall.ts
+++ b/frontend/src/pages/SinglePlay/Game/Wall.ts
@@ -20,15 +20,15 @@ export default class Walls {
     this.FIELD_WIDTH = this.experience.FIELD_WIDTH;
     this.FIELD_LENGTH = this.experience.FIELD_LENGTH;
 
-    this.wallGeometry = new THREE.BoxGeometry(10, 10, 3800, 5, 5, 500);
+    this.wallGeometry = new THREE.BoxGeometry(10, 20,this.experience.FIELD_LENGTH);
     this.wallMaterial = new THREE.MeshNormalMaterial({
       wireframe: true,
       transparent: true,
       opacity: 0.5,
     });
 
-    this.wallRight = this.createWall(450, 0, -550); // wallRight プロパティを初期化
-    this.wallLeft = this.createWall(-450, 0, -550); // wallLeft プロパティを初期化
+    this.wallRight = this.createWall(this.experience.FIELD_WIDTH / 2 + 5, 100, 0); // wallRight プロパティを初期化
+    this.wallLeft = this.createWall(-this.experience.FIELD_WIDTH / 2 - 5, 100, 0); // wallLeft プロパティを初期化
 
     this.setWallsRight();
     this.setWallsLeft();
@@ -42,11 +42,11 @@ export default class Walls {
   }
 
   private setWallsRight(): void {
-    this.wallRight.position.set(450, 0, -550);
+    this.wallRight.position.set(750, 0, 0);
   }
 
   private setWallsLeft(): void {
-    this.wallLeft.position.set(-450, 0, -550);
+    this.wallLeft.position.set(-750, 0, 0);
   }
 
   public update(): void {}

--- a/frontend/src/pages/SinglePlay/Game/World/Camera.ts
+++ b/frontend/src/pages/SinglePlay/Game/World/Camera.ts
@@ -42,8 +42,9 @@ export default class Camera {
 
   private createCamera(): THREE.PerspectiveCamera {
     const camera = this.experience.camera;
-    camera.position.set(0, 500, 2000);
-    camera.lookAt(0, 10, 0);  
+    camera.far = 5000;
+    camera.position.set(0, 600, 2200);
+    camera.lookAt(0, 0, 800);
     this.scene.add(camera);
     return camera;
   }
@@ -53,6 +54,10 @@ export default class Camera {
     controls.enableDamping = true;
     controls.dampingFactor = 0.25;
     controls.enableZoom = true;
+    controls.minDistance = 1000;
+    controls.maxDistance = 3000;
+    controls.minPolarAngle = Math.PI / 4;
+    controls.maxPolarAngle = Math.PI / 2;
     return controls;
   }
 

--- a/frontend/src/pages/SinglePlay/Game/World/Camera.ts
+++ b/frontend/src/pages/SinglePlay/Game/World/Camera.ts
@@ -4,7 +4,6 @@ import Experience from '../Experience';
 import Renderer from '../Utils/Renderer';
 
 export default class Camera {
-
   private experience: Experience;
   private renderer: Renderer;
   private scene: THREE.Scene;

--- a/frontend/src/pages/SinglePlay/Game/index.html
+++ b/frontend/src/pages/SinglePlay/Game/index.html
@@ -18,12 +18,25 @@
     </div>
     <div id="container">
       <canvas id="gl"></canvas>
-      <div id="scoreBoard"></div>
+      <div id="scoreDisplay">
+        <div class="score-container">
+          <div id="playerName">
+              <span class="leftName">Player</span>
+              <span class="vs">VS</span>
+              <span class="rightName">CPU</span>
+            </div>
+            <div id="score">
+              <span class="playerScore">0</span>
+              <span class="dash">-</span>
+              <span class="cpuScore">0</span>
+            </div>
+          </div>
+      </div>      
     </div>
     <div id="gameOver" class="hidden">
       <h1>Game Over</h1>
       <p>Your score: <span id="finalScore"></span></p>
     </div>
-    <!-- <script type="module" src="./index.ts"></script> -->
   </body>
 </html>
+

--- a/frontend/src/pages/SinglePlay/Game/index.ts
+++ b/frontend/src/pages/SinglePlay/Game/index.ts
@@ -60,7 +60,7 @@ const SinglePlayPage = new Page({
       if (running) {
         experience.update();
       }
-      // requestAnimationFrame(animate);
+      requestAnimationFrame(animate);
     }
     animate();
     setupPauseMenu();

--- a/frontend/src/pages/SinglePlay/Game/index.ts
+++ b/frontend/src/pages/SinglePlay/Game/index.ts
@@ -59,7 +59,6 @@ const SinglePlayPage = new Page({
       }
     }
 
-
     const selectedLevel = localStorage.getItem('selectedLevel');
     console.log(`Retrieved selected level: ${selectedLevel}`);
 

--- a/frontend/src/pages/SinglePlay/Game/index.ts
+++ b/frontend/src/pages/SinglePlay/Game/index.ts
@@ -60,7 +60,7 @@ const SinglePlayPage = new Page({
       if (running) {
         experience.update();
       }
-      requestAnimationFrame(animate);
+      // requestAnimationFrame(animate);
     }
     animate();
     setupPauseMenu();

--- a/frontend/src/pages/SinglePlay/Game/index.ts
+++ b/frontend/src/pages/SinglePlay/Game/index.ts
@@ -49,6 +49,17 @@ const SinglePlayPage = new Page({
     if (header) header.classList.add('none');
     if (background) background.classList.add('none');
 
+    const username = localStorage.getItem('username') || 'Player';
+    const playerNameDiv = document.getElementById('playerName');
+    if (playerNameDiv) {
+      // すでに HTML 内に「<span class="leftName">Player</span><span class="vs">VS</span><span class="rightName">CPU</span>」があると仮定
+      const leftNameSpan = playerNameDiv.querySelector('.leftName');
+      if (leftNameSpan) {
+        leftNameSpan.textContent = username;
+      }
+    }
+
+
     const selectedLevel = localStorage.getItem('selectedLevel');
     console.log(`Retrieved selected level: ${selectedLevel}`);
 

--- a/frontend/src/pages/SinglePlay/Game/style.css
+++ b/frontend/src/pages/SinglePlay/Game/style.css
@@ -160,3 +160,49 @@ canvas {
   opacity: 1; /* 表示状態 */
   visibility: visible; /* 表示状態 */
 }
+
+/* scoreDisplay全体を画面上部中央に配置 */
+#scoreDisplay {
+  position: fixed;
+  top: 50px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  pointer-events: none;
+  visibility: visible;
+}
+
+.score-container {
+  background-color: rgba(0, 0, 0, 0.6); /* 半透明の黒 */
+  padding: 10px 20px;
+  border-radius: 10px;
+  text-align: center;
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+}
+
+/* 各行を横並びにして中央揃え */
+#playerName, #score {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* 左右の余白を調整して、VS と - が中央に来るように */
+#playerName .vs, #score .dash {
+  margin: 0 10px;
+}
+
+/* ゲームオーバー表示（例） */
+#gameOver {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #fff;
+  text-align: center;
+  z-index: 1100;
+  background-color: rgba(0, 0, 0, 0.7);
+  padding: 20px;
+  border-radius: 10px;
+}


### PR DESCRIPTION
## 概要

ピンポンゲーム15点先取ロジック成立
（現在は5点に設定）

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

> ・paddle○
> ・ball○
> ・wall○
> ・field○
> ・boardー＞ボードは表示してない
> ・scoreboard○
> ・15p先取ロジック○


## 影響範囲
singleplay/
score

## テスト
今後
・paddle, ballのレベル段階をつける
・wallでのball跳ね返り位置を調整。

## 関連Issue

- 関連Issue: #123
