### PR TITLE
INVALID: /resultのデータ修正 #150

### DIFF
--- a/api/pong/consumers.py
+++ b/api/pong/consumers.py
@@ -78,9 +78,11 @@ class MatchmakingConsumer(AsyncWebsocketConsumer):
         if len(self.waiting_players) >= 2:
             player1 = self.waiting_players.pop(0)
             player2 = self.waiting_players.pop(0)
-            
+
             # データベースにゲームレコードを作成
-            session_id = await self.create_game_record(player1.username, player2.username)
+            session_id = await self.create_game_record(
+                player1.username, player2.username
+            )
 
             match_data = {
                 "type": "match_found",
@@ -97,14 +99,16 @@ class MatchmakingConsumer(AsyncWebsocketConsumer):
     def create_game_record(self, player1_username, player2_username):
         """データベースにゲームレコードを事前作成"""
         from .serializers import generate_session_id
-        
+
         try:
             player1 = User.objects.get(username=player1_username)
             player2 = User.objects.get(username=player2_username)
-            
+
             # セッションID生成 - シリアライザーと同じ関数を使用
-            session_id = generate_session_id("MULTI", player1_username, player2_username)
-            
+            session_id = generate_session_id(
+                "MULTI", player1_username, player2_username
+            )
+
             # ゲームレコード作成
             Game.objects.create(
                 game_type="MULTI",
@@ -112,11 +116,11 @@ class MatchmakingConsumer(AsyncWebsocketConsumer):
                 session_id=session_id,
                 player1=player1,
                 player2=player2,
-                is_ai_opponent=False
+                is_ai_opponent=False,
             )
-            
+
             return session_id
-        
+
         except Exception as e:
             print(f"Error creating game record: {e}")
             # フォールバック

--- a/api/pong/serializers.py
+++ b/api/pong/serializers.py
@@ -110,7 +110,7 @@ class LoginSerializer(serializers.Serializer):
             )
         raise serializers.ValidationError('Must include "username" and "password".')
 
-
+# TODO: add validate dup sessionID
 class GameSerializer(serializers.ModelSerializer):
     player1 = serializers.CharField(source="player1.username")
     player2 = serializers.CharField(

--- a/api/pong/urls.py
+++ b/api/pong/urls.py
@@ -3,6 +3,8 @@ from django.urls import path
 from .views import (
     AddFriendView,
     FriendListView,
+    GameListCreateView,
+    GameRetrieveUpdateDestroyView,
     HealthCheckView,
     LoginView,
     LogoutView,
@@ -52,5 +54,12 @@ urlpatterns = [
     # Logout
     path("logout/", LogoutView.as_view(), name="logout"),
     # Game
+    path("games/", GameListCreateView.as_view(), name="game-list-create"),
+    ## セッションIDによるゲーム取得・更新・削除のエンドポイント
+    path(
+        "games/session/<str:session_id>/", 
+        GameRetrieveUpdateDestroyView.as_view(), 
+        name="game-detail-by-session"
+    ),
     # Tournament
 ]

--- a/api/pong/urls.py
+++ b/api/pong/urls.py
@@ -3,8 +3,6 @@ from django.urls import path
 from .views import (
     AddFriendView,
     FriendListView,
-    GameListCreateView,
-    GameRetrieveUpdateDestroyView,
     HealthCheckView,
     LoginView,
     LogoutView,
@@ -54,9 +52,5 @@ urlpatterns = [
     # Logout
     path("logout/", LogoutView.as_view(), name="logout"),
     # Game
-    path("games/", GameListCreateView.as_view(), name="game-list-create"),
-    path(
-        "games/<int:pk>/", GameRetrieveUpdateDestroyView.as_view(), name="game-detail"
-    ),
     # Tournament
 ]

--- a/api/pong/views.py
+++ b/api/pong/views.py
@@ -9,6 +9,7 @@ from rest_framework.views import APIView
 from core.logger import logger
 
 from .models import Game, User
+from .permissions import IsPlayerOrReadOnly
 from .serializers import (
     FriendSerializer,
     GameSerializer,
@@ -284,69 +285,8 @@ class GameListCreateView(generics.ListCreateAPIView):
             status=status.HTTP_201_CREATED,
         )
 
-
-# TODO: これ要らないかも???
-class GameViewSet(viewsets.ModelViewSet):
+class GameRetrieveUpdateDestroyView(generics.RetrieveUpdateDestroyAPIView):
     queryset = Game.objects.all()
     serializer_class = GameSerializer
-    permission_classes = [IsAuthenticated]
-
-    def create(self, request, *args, **kwargs):
-        """ゲーム作成またはセッションIDがある場合は更新"""
-        session_id = request.data.get("session_id")
-
-        # セッションIDが提供された場合は既存ゲームを更新
-        if session_id:
-            try:
-                game = Game.objects.get(session_id=session_id)
-                serializer = self.get_serializer(game, data=request.data, partial=True)
-                serializer.is_valid(raise_exception=True)
-                serializer.save()
-                return Response(serializer.data)
-            except Game.DoesNotExist:
-                pass  # セッションIDが見つからない場合は新規作成
-
-        # 通常の作成処理
-        return super().create(request, *args, **kwargs)
-
-    @action(detail=False, methods=["put"], url_path="update-result")
-    def update_result(self, request):
-        """ゲーム結果の更新専用エンドポイント"""
-        session_id = request.data.get("session_id")
-        if not session_id:
-            return Response(
-                {"error": "Session ID is required"}, status=status.HTTP_400_BAD_REQUEST
-            )
-
-        try:
-            game = Game.objects.get(session_id=session_id)
-
-            # オプション: player1のみが更新できるようにする場合
-            # if request.user.username != game.player1.username:
-            #     return Response(
-            #         {'error': 'Only player1 can update game results'},
-            #         status=status.HTTP_403_FORBIDDEN
-            #     )
-
-            # 既に完了している場合は重複更新防止
-            if game.status == "COMPLETED" and game.end_time is not None:
-                return Response(
-                    {
-                        "message": "Game is already completed",
-                        "data": GameSerializer(game).data,
-                    },
-                    status=status.HTTP_200_OK,  # エラーではなく情報提供
-                )
-
-            # 結果を更新
-            serializer = GameSerializer(game, data=request.data, partial=True)
-            serializer.is_valid(raise_exception=True)
-            serializer.save()
-
-            return Response(serializer.data)
-
-        except Game.DoesNotExist:
-            return Response(
-                {"error": "Game not found with this session ID"},
-                status=status.HTTP_404_NOT_FOUND,
-            )
+    permission_classes = [IsAuthenticated, IsPlayerOrReadOnly]
+    lookup_field = 'session_id'

--- a/api/pong/views.py
+++ b/api/pong/views.py
@@ -9,7 +9,6 @@ from rest_framework.views import APIView
 from core.logger import logger
 
 from .models import Game, User
-from .permissions import IsPlayerOrReadOnly
 from .serializers import (
     FriendSerializer,
     GameSerializer,
@@ -285,16 +284,17 @@ class GameListCreateView(generics.ListCreateAPIView):
             status=status.HTTP_201_CREATED,
         )
 
+
 # TODO: これ要らないかも???
 class GameViewSet(viewsets.ModelViewSet):
     queryset = Game.objects.all()
     serializer_class = GameSerializer
     permission_classes = [IsAuthenticated]
-    
+
     def create(self, request, *args, **kwargs):
         """ゲーム作成またはセッションIDがある場合は更新"""
-        session_id = request.data.get('session_id')
-        
+        session_id = request.data.get("session_id")
+
         # セッションIDが提供された場合は既存ゲームを更新
         if session_id:
             try:
@@ -305,46 +305,48 @@ class GameViewSet(viewsets.ModelViewSet):
                 return Response(serializer.data)
             except Game.DoesNotExist:
                 pass  # セッションIDが見つからない場合は新規作成
-        
+
         # 通常の作成処理
         return super().create(request, *args, **kwargs)
-    
-    @action(detail=False, methods=['put'], url_path='update-result')
+
+    @action(detail=False, methods=["put"], url_path="update-result")
     def update_result(self, request):
         """ゲーム結果の更新専用エンドポイント"""
-        session_id = request.data.get('session_id')
+        session_id = request.data.get("session_id")
         if not session_id:
             return Response(
-                {'error': 'Session ID is required'}, 
-                status=status.HTTP_400_BAD_REQUEST
+                {"error": "Session ID is required"}, status=status.HTTP_400_BAD_REQUEST
             )
-        
+
         try:
             game = Game.objects.get(session_id=session_id)
-            
+
             # オプション: player1のみが更新できるようにする場合
             # if request.user.username != game.player1.username:
             #     return Response(
-            #         {'error': 'Only player1 can update game results'}, 
+            #         {'error': 'Only player1 can update game results'},
             #         status=status.HTTP_403_FORBIDDEN
             #     )
-            
+
             # 既に完了している場合は重複更新防止
-            if game.status == 'COMPLETED' and game.end_time is not None:
+            if game.status == "COMPLETED" and game.end_time is not None:
                 return Response(
-                    {'message': 'Game is already completed', 'data': GameSerializer(game).data},
-                    status=status.HTTP_200_OK  # エラーではなく情報提供
+                    {
+                        "message": "Game is already completed",
+                        "data": GameSerializer(game).data,
+                    },
+                    status=status.HTTP_200_OK,  # エラーではなく情報提供
                 )
-            
+
             # 結果を更新
             serializer = GameSerializer(game, data=request.data, partial=True)
             serializer.is_valid(raise_exception=True)
             serializer.save()
-            
+
             return Response(serializer.data)
-        
+
         except Game.DoesNotExist:
             return Response(
-                {'error': 'Game not found with this session ID'}, 
-                status=status.HTTP_404_NOT_FOUND
+                {"error": "Game not found with this session ID"},
+                status=status.HTTP_404_NOT_FOUND,
             )

--- a/frontend/src/models/MultiPlay/MultiplayerGameManager.ts
+++ b/frontend/src/models/MultiPlay/MultiplayerGameManager.ts
@@ -98,6 +98,7 @@ export class MultiplayerGameManager extends BaseGameManager {
       player1: data.state.score[this.config.username] || 0,
       player2: data.state.score[opponent] || 0,
       opponent: opponent,
+      sessionId: this.config.sessionId,
     };
 
     localStorage.setItem('finalScore', JSON.stringify(finalScore));

--- a/frontend/src/models/MultiPlay/MultiplayerGameManager.ts
+++ b/frontend/src/models/MultiPlay/MultiplayerGameManager.ts
@@ -55,10 +55,11 @@ export class MultiplayerGameManager extends BaseGameManager {
     localStorage.setItem('finalScore', JSON.stringify(finalScore));
     localStorage.setItem('gameMode', 'multiplayer');
 
+    console.log('----- onPlayerDisconnected() -----');
     // 結果画面に遷移
-    setTimeout(() => {
-      window.location.href = '/result';
-    }, 1000);
+    // setTimeout(() => {
+    //   window.location.href = '/result';
+    // }, 1000);
   }
 
   protected onConnectionError(): void {
@@ -79,8 +80,9 @@ export class MultiplayerGameManager extends BaseGameManager {
     localStorage.setItem('finalScore', JSON.stringify(finalScore));
     localStorage.setItem('gameMode', 'multiplayer');
 
+    console.log('----- onConnectionError() -----');
     // 結果画面に遷移
-    window.location.href = '/result';
+    // window.location.href = '/result';
   }
 
   protected onError(message: string): void {
@@ -104,9 +106,10 @@ export class MultiplayerGameManager extends BaseGameManager {
     localStorage.setItem('finalScore', JSON.stringify(finalScore));
     localStorage.setItem('gameMode', 'multiplayer');
 
-    setTimeout(() => {
-      window.location.href = '/result';
-    }, 1000);
+    console.log('----- onGameEnd() -----');
+    // setTimeout(() => {
+    //   window.location.href = '/result';
+    // }, 1000);
   }
 
   protected onCleanup(): void {

--- a/frontend/src/models/Result/GameResultService.ts
+++ b/frontend/src/models/Result/GameResultService.ts
@@ -132,6 +132,7 @@ export class GameResultService {
       console.log('Response status:', response.status);
 
       const responseData = await response.json();
+      // NOTE: PUTが許可されていないと表示される
       console.log('Response data:', responseData);
 
       if (!response.ok) {

--- a/frontend/src/models/Result/GameResultService.ts
+++ b/frontend/src/models/Result/GameResultService.ts
@@ -1,0 +1,184 @@
+// src/models/Result/GameResultService.ts
+import { API_URL } from '@/config/config';
+import { IGameResult, IGameMode } from '@/models/interface';
+
+/**
+ * ゲーム結果に関するサービスクラス
+ * バックエンドとの通信とゲーム結果データの管理を担当
+ */
+export class GameResultService {
+  /**
+   * ローカルストレージからゲーム結果を取得
+   */
+  static getStoredResult(): { score: IGameResult; gameMode: IGameMode } | null {
+    const storedScore = localStorage.getItem('finalScore');
+    const gameMode = localStorage.getItem('gameMode') as IGameMode || 'singleplayer';
+    
+    if (!storedScore) return null;
+    
+    try {
+      const score = JSON.parse(storedScore);
+      return { score, gameMode };
+    } catch (error) {
+      console.error('Failed to parse stored score:', error);
+      return null;
+    }
+  }
+  
+  /**
+   * ローカルストレージからゲーム結果をクリア
+   */
+  static clearStoredResult(): void {
+    localStorage.removeItem('finalScore');
+    localStorage.removeItem('gameMode');
+  }
+  
+  /**
+   * ゲームモードに基づいたAPIリクエストデータを構築
+   */
+  static buildGameData(score: IGameResult, gameMode: IGameMode, username: string): any {
+    // 基本データ構造
+    const baseData = {
+      status: 'COMPLETED',
+      end_time: new Date().toISOString(),
+    };
+    
+    // ゲームモード別データ構築
+    if (gameMode === 'singleplayer') {
+      return {
+        ...baseData,
+        game_type: 'SINGLE',
+        player1: username,
+        player2: null,
+        score_player1: score.player1,
+        score_player2: score.player2,
+        is_ai_opponent: true,
+        winner: score.player1 > score.player2 ? username : null,
+      };
+    } 
+    
+    if (gameMode === 'multiplayer') {
+      const isWinner = score.player1 > score.player2;
+      const gameData = {
+        ...baseData,
+        game_type: 'MULTI',
+        player1: username,
+        player2: score.opponent,
+        score_player1: score.player1,
+        score_player2: score.player2,
+        is_ai_opponent: false,
+        winner: isWinner ? username : score.opponent,
+      };
+      
+      // 切断情報処理
+      if (score.disconnected) {
+        gameData.winner = score.disconnectedPlayer === username ? score.opponent : username;
+      }
+      
+      return gameData;
+    }
+    
+    if (gameMode === 'tournament') {
+      // TODO: トーナメントモード用データ構築
+      return {
+        ...baseData,
+        game_type: 'TOURNAMENT',
+        // 他のトーナメント固有フィールド
+      };
+    }
+    
+    return baseData;
+  }
+  
+  /**
+   * ゲーム結果をバックエンドに送信
+   */
+  static async sendGameResult(score: IGameResult, gameMode: IGameMode): Promise<boolean> {
+    try {
+      const token = localStorage.getItem('token');
+      const username = localStorage.getItem('username');
+      
+      if (!token || !username) {
+        console.error('Authentication data missing');
+        return false;
+      }
+      
+      const gameData = this.buildGameData(score, gameMode, username);
+      
+      const response = await fetch(`${API_URL}/api/games/`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Token ${token}`,
+        },
+        credentials: 'include',
+        body: JSON.stringify(gameData),
+      });
+      
+      // デバッグログ
+      console.log('Request payload:', gameData);
+      console.log('Response status:', response.status);
+      
+      const responseData = await response.json();
+      console.log('Response data:', responseData);
+      
+      if (!response.ok) {
+        throw new Error(`API error: ${response.status}`);
+      }
+      
+      console.log('Game result saved successfully');
+      return true;
+    } catch (error) {
+      console.error('Error saving game result:', error);
+      return false;
+    }
+  }
+  
+  /**
+   * 勝者を判定
+   */
+  static determineWinner(score: IGameResult, username: string): {
+    isWinner: boolean;
+    message: string;
+    className: string;
+  } {
+    // 切断による勝敗
+    if (score.disconnected) {
+      const wasDisconnected = score.disconnectedPlayer === username;
+      if (wasDisconnected) {
+        return {
+          isWinner: false,
+          message: 'You Disconnected - Opponent Wins',
+          className: 'result-message lose',
+        };
+      } else {
+        return {
+          isWinner: true,
+          message: 'Opponent Disconnected - You Win!',
+          className: 'result-message win',
+        };
+      }
+    }
+    
+    // 通常スコアによる勝敗
+    if (score.player1 > score.player2) {
+      return {
+        isWinner: true,
+        message: 'You Win!',
+        className: 'result-message win',
+      };
+    } else if (score.player1 < score.player2) {
+      return {
+        isWinner: false,
+        message: 'Opponent Wins!',
+        className: 'result-message lose',
+      };
+    } else {
+      return {
+        isWinner: false,
+        message: 'Draw!',
+        className: 'result-message draw',
+      };
+    }
+  }
+}

--- a/frontend/src/models/Result/GameResultService.ts
+++ b/frontend/src/models/Result/GameResultService.ts
@@ -106,12 +106,18 @@ export class GameResultService {
       const gameData = this.buildGameData(score, gameMode, username);
 
       // HTTPメソッドとエンドポイントの設定
-      let method = 'PUT';
+      // FIXME: これ全部PUTでいいのでは
+      let method = 'PUT'; // デフォルトは PUT
+      let endpoint = `${API_URL}/api/games/`;
+
       if (gameMode === 'singleplayer') {
-        method = 'POST';
+        method = 'POST'; // シングルプレイヤーは POST
+      } else if (gameMode === 'multiplayer' && score.sessionId) {
+        // マルチプレイヤーでセッションIDがある場合、エンドポイントを変更
+        endpoint = `${API_URL}/api/games/session/${score.sessionId}/`;
       }
 
-      const response = await fetch(`${API_URL}/api/games/`, {
+      const response = await fetch(endpoint, {
         method: method,
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/models/Result/GameResultService.ts
+++ b/frontend/src/models/Result/GameResultService.ts
@@ -12,10 +12,10 @@ export class GameResultService {
    */
   static getStoredResult(): { score: IGameResult; gameMode: IGameMode } | null {
     const storedScore = localStorage.getItem('finalScore');
-    const gameMode = localStorage.getItem('gameMode') as IGameMode || 'singleplayer';
-    
+    const gameMode = (localStorage.getItem('gameMode') as IGameMode) || 'singleplayer';
+
     if (!storedScore) return null;
-    
+
     try {
       const score = JSON.parse(storedScore);
       return { score, gameMode };
@@ -24,7 +24,7 @@ export class GameResultService {
       return null;
     }
   }
-  
+
   /**
    * ローカルストレージからゲーム結果をクリア
    */
@@ -32,7 +32,7 @@ export class GameResultService {
     localStorage.removeItem('finalScore');
     localStorage.removeItem('gameMode');
   }
-  
+
   /**
    * ゲームモードに基づいたAPIリクエストデータを構築
    */
@@ -42,7 +42,7 @@ export class GameResultService {
       status: 'COMPLETED',
       end_time: new Date().toISOString(),
     };
-    
+
     // ゲームモード別データ構築
     if (gameMode === 'singleplayer') {
       return {
@@ -55,8 +55,8 @@ export class GameResultService {
         is_ai_opponent: true,
         winner: score.player1 > score.player2 ? username : null,
       };
-    } 
-    
+    }
+
     if (gameMode === 'multiplayer') {
       const isWinner = score.player1 > score.player2;
       const gameData = {
@@ -69,15 +69,15 @@ export class GameResultService {
         is_ai_opponent: false,
         winner: isWinner ? username : score.opponent,
       };
-      
+
       // 切断情報処理
       if (score.disconnected) {
         gameData.winner = score.disconnectedPlayer === username ? score.opponent : username;
       }
-      
+
       return gameData;
     }
-    
+
     if (gameMode === 'tournament') {
       // TODO: トーナメントモード用データ構築
       return {
@@ -86,10 +86,10 @@ export class GameResultService {
         // 他のトーナメント固有フィールド
       };
     }
-    
+
     return baseData;
   }
-  
+
   /**
    * ゲーム結果をバックエンドに送信
    */
@@ -97,16 +97,22 @@ export class GameResultService {
     try {
       const token = localStorage.getItem('token');
       const username = localStorage.getItem('username');
-      
+
       if (!token || !username) {
         console.error('Authentication data missing');
         return false;
       }
-      
+
       const gameData = this.buildGameData(score, gameMode, username);
-      
+
+      // HTTPメソッドとエンドポイントの設定
+      let method = 'PUT';
+      if (gameMode === 'singleplayer') {
+        method = 'POST';
+      }
+
       const response = await fetch(`${API_URL}/api/games/`, {
-        method: 'POST',
+        method: method,
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Token ${token}`,
@@ -114,18 +120,18 @@ export class GameResultService {
         credentials: 'include',
         body: JSON.stringify(gameData),
       });
-      
+
       // デバッグログ
       console.log('Request payload:', gameData);
       console.log('Response status:', response.status);
-      
+
       const responseData = await response.json();
       console.log('Response data:', responseData);
-      
+
       if (!response.ok) {
         throw new Error(`API error: ${response.status}`);
       }
-      
+
       console.log('Game result saved successfully');
       return true;
     } catch (error) {
@@ -133,11 +139,14 @@ export class GameResultService {
       return false;
     }
   }
-  
+
   /**
    * 勝者を判定
    */
-  static determineWinner(score: IGameResult, username: string): {
+  static determineWinner(
+    score: IGameResult,
+    username: string
+  ): {
     isWinner: boolean;
     message: string;
     className: string;
@@ -159,7 +168,7 @@ export class GameResultService {
         };
       }
     }
-    
+
     // 通常スコアによる勝敗
     if (score.player1 > score.player2) {
       return {

--- a/frontend/src/models/Result/ResultPageUI.ts
+++ b/frontend/src/models/Result/ResultPageUI.ts
@@ -25,15 +25,15 @@ export class ResultPageUI {
     this.playerScoreElement = document.getElementById('playerScore');
     this.opponentScoreElement = document.getElementById('cpuScore');
     this.resultMessage = document.getElementById('result-message');
-    
+
     // プレイヤー情報要素
     this.playerNameElement = document.getElementById('playerName');
     this.opponentNameElement = document.querySelector('.cpu-side .player-name');
-    
+
     // アバター要素
     this.playerAvatarImg = document.getElementById('player-avatar') as HTMLImageElement;
     this.opponentAvatarImg = document.getElementById('opponent-avatar') as HTMLImageElement;
-    
+
     // 操作ボタン
     this.exitBtn = document.getElementById('exitBtn');
   }
@@ -96,7 +96,7 @@ export class ResultPageUI {
     if (this.playerScoreElement) {
       this.playerScoreElement.textContent = String(player1Score);
     }
-    
+
     if (this.opponentScoreElement) {
       this.opponentScoreElement.textContent = String(player2Score);
     }
@@ -115,19 +115,23 @@ export class ResultPageUI {
   /**
    * 結果画面全体の更新
    */
-  async updateResultView(score: IGameResult, username: string, resultInfo: {
-    message: string;
-    className: string;
-  }): Promise<void> {
+  async updateResultView(
+    score: IGameResult,
+    username: string,
+    resultInfo: {
+      message: string;
+      className: string;
+    }
+  ): Promise<void> {
     // スコア表示
     this.displayScores(score.player1, score.player2);
-    
+
     // プレイヤー名表示
     this.displayPlayerNames(username, score.opponent);
-    
+
     // アバター表示
     await this.displayPlayerAvatars(username, score.opponent);
-    
+
     // 勝敗メッセージ表示
     this.displayResultMessage(resultInfo.message, resultInfo.className);
   }

--- a/frontend/src/models/Result/ResultPageUI.ts
+++ b/frontend/src/models/Result/ResultPageUI.ts
@@ -1,0 +1,134 @@
+// src/models/Result/ResultPageUI.ts
+
+import { API_URL } from '@/config/config';
+import { fetchUserAvatar } from '@/models/User/repository';
+import { IGameResult } from '@/models/interface';
+
+/**
+ * 結果画面のUI操作を担当するクラス
+ */
+export class ResultPageUI {
+  private playerScoreElement: HTMLElement | null;
+  private opponentScoreElement: HTMLElement | null;
+  private resultMessage: HTMLElement | null;
+  private playerNameElement: HTMLElement | null;
+  private opponentNameElement: HTMLElement | null;
+  private playerAvatarImg: HTMLImageElement | null;
+  private opponentAvatarImg: HTMLImageElement | null;
+  private exitBtn: HTMLElement | null;
+
+  /**
+   * コンストラクタ - DOM要素の初期化
+   */
+  constructor() {
+    // スコア関連要素
+    this.playerScoreElement = document.getElementById('playerScore');
+    this.opponentScoreElement = document.getElementById('cpuScore');
+    this.resultMessage = document.getElementById('result-message');
+    
+    // プレイヤー情報要素
+    this.playerNameElement = document.getElementById('playerName');
+    this.opponentNameElement = document.querySelector('.cpu-side .player-name');
+    
+    // アバター要素
+    this.playerAvatarImg = document.getElementById('player-avatar') as HTMLImageElement;
+    this.opponentAvatarImg = document.getElementById('opponent-avatar') as HTMLImageElement;
+    
+    // 操作ボタン
+    this.exitBtn = document.getElementById('exitBtn');
+  }
+
+  /**
+   * 終了ボタンのイベントハンドラを設定
+   */
+  setupEventHandlers(callback: () => void): void {
+    this.exitBtn?.addEventListener('click', callback);
+  }
+
+  /**
+   * プレイヤー名を表示
+   */
+  displayPlayerNames(username: string, opponent: string | undefined): void {
+    if (this.playerNameElement && username) {
+      this.playerNameElement.textContent = username;
+    }
+
+    if (this.opponentNameElement && opponent) {
+      this.opponentNameElement.textContent = opponent;
+    }
+  }
+
+  /**
+   * プレイヤーアバターを表示
+   */
+  async displayPlayerAvatars(username: string, opponent: string | undefined): Promise<void> {
+    if (!this.playerAvatarImg || !this.opponentAvatarImg) return;
+
+    // プレイヤーアバターの取得と表示
+    if (username) {
+      const avatar = await fetchUserAvatar(username);
+      if (avatar && avatar.type.startsWith('image/')) {
+        const avatarUrl = URL.createObjectURL(avatar);
+        this.playerAvatarImg.src = avatarUrl;
+      } else {
+        this.playerAvatarImg.src = `${API_URL}/media/default_avatar.png`;
+      }
+      this.playerAvatarImg.alt = username;
+    }
+
+    // 対戦相手アバターの取得と表示
+    if (opponent) {
+      const avatar = await fetchUserAvatar(opponent);
+      if (avatar && avatar.type.startsWith('image/')) {
+        const avatarUrl = URL.createObjectURL(avatar);
+        this.opponentAvatarImg.src = avatarUrl;
+      } else {
+        this.opponentAvatarImg.src = `${API_URL}/media/default_avatar.png`;
+      }
+      this.opponentAvatarImg.alt = opponent;
+    }
+  }
+
+  /**
+   * スコアを表示
+   */
+  displayScores(player1Score: number, player2Score: number): void {
+    if (this.playerScoreElement) {
+      this.playerScoreElement.textContent = String(player1Score);
+    }
+    
+    if (this.opponentScoreElement) {
+      this.opponentScoreElement.textContent = String(player2Score);
+    }
+  }
+
+  /**
+   * 勝敗結果メッセージを表示
+   */
+  displayResultMessage(message: string, className: string): void {
+    if (this.resultMessage) {
+      this.resultMessage.textContent = message;
+      this.resultMessage.className = className;
+    }
+  }
+
+  /**
+   * 結果画面全体の更新
+   */
+  async updateResultView(score: IGameResult, username: string, resultInfo: {
+    message: string;
+    className: string;
+  }): Promise<void> {
+    // スコア表示
+    this.displayScores(score.player1, score.player2);
+    
+    // プレイヤー名表示
+    this.displayPlayerNames(username, score.opponent);
+    
+    // アバター表示
+    await this.displayPlayerAvatars(username, score.opponent);
+    
+    // 勝敗メッセージ表示
+    this.displayResultMessage(resultInfo.message, resultInfo.className);
+  }
+}

--- a/frontend/src/models/interface.ts
+++ b/frontend/src/models/interface.ts
@@ -31,6 +31,7 @@ export interface IGameResult {
   opponent?: string;
   disconnected?: boolean;
   disconnectedPlayer?: string;
+  sessionId?: string;
 }
 
 export type IGameMode = 'singleplayer' | 'multiplayer' | 'tournament';

--- a/frontend/src/models/interface.ts
+++ b/frontend/src/models/interface.ts
@@ -24,6 +24,17 @@ export interface IRankingUser {
   level: number;
 }
 
+// ==== result =====
+export interface IGameResult {
+  player1: number;
+  player2: number;
+  opponent?: string;
+  disconnected?: boolean;
+  disconnectedPlayer?: string;
+}
+
+export type IGameMode = 'singleplayer' | 'multiplayer' | 'tournament';
+
 // ===== Game =====
 export interface IGameScore {
   player1: number;

--- a/frontend/src/pages/Result/index.ts
+++ b/frontend/src/pages/Result/index.ts
@@ -18,7 +18,7 @@ const ResultPage = new Page({
   mounted: async ({ pg }: { pg: Page }): Promise<void> => {
     // 認証チェック
     checkUserAccess();
-    
+
     // ユーザー名取得
     const username = localStorage.getItem('username');
     if (!username) {
@@ -26,40 +26,40 @@ const ResultPage = new Page({
       window.location.href = '/';
       return;
     }
-    
+
     // 結果データ取得
     const resultData = GameResultService.getStoredResult();
     if (!resultData) {
       console.warn('No game result data found');
       return;
     }
-    
+
     const { score, gameMode } = resultData;
-    
+
     // UI初期化
     const ui = new ResultPageUI();
-    
+
     // 終了ボタン設定
     ui.setupEventHandlers(() => {
       window.location.href = '/modes';
     });
-    
+
     // 勝敗判定
     const winnerInfo = GameResultService.determineWinner(score, username);
-    
+
     // 画面表示更新
     await ui.updateResultView(score, username, {
       message: winnerInfo.message,
       className: winnerInfo.className,
     });
-    
+
     // 結果をサーバーに送信
     try {
       await GameResultService.sendGameResult(score, gameMode);
     } catch (error) {
       console.error('Error saving game result:', error);
     }
-    
+
     // 保存データのクリア
     GameResultService.clearStoredResult();
   },

--- a/frontend/src/pages/Result/index.ts
+++ b/frontend/src/pages/Result/index.ts
@@ -1,3 +1,4 @@
+// frontend/src/pages/Result/index.ts
 import { API_URL } from '@/config/config';
 import { Page } from '@/core/Page';
 import CommonLayout from '@/layouts/common/index';

--- a/frontend/src/pages/Result/index.ts
+++ b/frontend/src/pages/Result/index.ts
@@ -1,179 +1,67 @@
 // frontend/src/pages/Result/index.ts
-import { API_URL } from '@/config/config';
+
 import { Page } from '@/core/Page';
 import CommonLayout from '@/layouts/common/index';
-import { IGameScore } from '@/models/interface';
 import { checkUserAccess } from '@/models/User/auth';
-import { fetchUserAvatar } from '@/models/User/repository';
+import { GameResultService } from '@/models/Result/GameResultService';
+import { ResultPageUI } from '@/models/Result/ResultPageUI';
 
-async function sendGameResult(score: any, gameMode: string) {
-  try {
-    const token = localStorage.getItem('token');
-    const username = localStorage.getItem('username');
-    
-    let gameData: any = {
-      status: 'COMPLETED',
-      end_time: new Date().toISOString(),
-    };
-    
-    // ゲームモードに応じたデータ構造を構築
-    if (gameMode === 'singleplayer') {
-      // シングルプレイヤー (CPU対戦) モード
-      gameData = {
-        ...gameData,
-        game_type: 'SINGLE',
-        player1: username,
-        player2: null,
-        score_player1: score.player1,
-        score_player2: score.player2,
-        is_ai_opponent: true,
-        winner: score.player1 > score.player2 ? username : null,
-      };
-    } else if (gameMode === 'multiplayer') {
-      // マルチプレイヤーモード
-      const isWinner = score.player1 > score.player2;
-      
-      gameData = {
-        ...gameData,
-        game_type: 'MULTI',
-        player1: username,
-        player2: score.opponent,
-        score_player1: score.player1,
-        score_player2: score.player2,
-        is_ai_opponent: false,
-        winner: isWinner ? username : score.opponent,
-      };
-      
-      // 切断情報があれば処理
-      if (score.disconnected) {
-        gameData.winner = score.disconnectedPlayer === username ? score.opponent : username;
-      }
-    } 
-    // TODO: トーナメントモードは将来的に追加予定
-    // else if (gameMode === 'tournament') { ... }
-
-    const response = await fetch(`${API_URL}/api/games/`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Token ${token}`,
-      },
-      credentials: 'include',
-      body: JSON.stringify(gameData),
-    });
-
-    // デバッグ用のログを追加
-    console.log('Request payload:', gameData);
-    console.log('Response status:', response.status);
-    const responseData = await response.json();
-    console.log('Response data:', responseData);
-
-    if (!response.ok) {
-      throw new Error('Failed to save game result');
-    }
-
-    console.log('Game result saved successfully');
-  } catch (error) {
-    console.error('Error saving game result:', error);
-  }
-}
-
+/**
+ * 結果画面ページコンポーネント
+ * 全体のフローを制御し、各サービスを連携
+ */
 const ResultPage = new Page({
   name: 'Result',
   config: {
     layout: CommonLayout,
   },
   mounted: async ({ pg }: { pg: Page }): Promise<void> => {
+    // 認証チェック
     checkUserAccess();
-    const storedScore = localStorage.getItem('finalScore');
-    const gameMode = localStorage.getItem('gameMode') || 'singleplayer';
+    
+    // ユーザー名取得
     const username = localStorage.getItem('username');
-
-    if (storedScore) {
-      const score = JSON.parse(storedScore);
-
-      // スコアの表示を更新
-      const playerScoreElement = document.getElementById('playerScore');
-      const opponentScoreElement = document.getElementById('cpuScore');
-      const resultMessage = document.getElementById('result-message');
-      const playerNameElement = document.getElementById('playerName');
-      const opponentNameElement = document.querySelector('.cpu-side .player-name');
-
-      if (playerNameElement && username) {
-        playerNameElement.textContent = username;
-      }
-
-      if (opponentNameElement && score.opponent) {
-        opponentNameElement.textContent = score.opponent;
-      }
-
-      const playerAvatarImg = document.getElementById('player-avatar') as HTMLImageElement;
-      const opponentAvatarImg = document.getElementById('opponent-avatar') as HTMLImageElement;
-      if (playerAvatarImg && opponentAvatarImg && username) {
-        fetchUserAvatar(username).then((avatar) => {
-          if (avatar && avatar.type.startsWith('image/')) {
-            const avatarUrl = URL.createObjectURL(avatar);
-            playerAvatarImg.src = avatarUrl;
-          } else {
-            playerAvatarImg.src = `${API_URL}/media/default_avatar.png`;
-          }
-        });
-        playerAvatarImg.alt = username;
-        
-        if (score.opponent) {
-          fetchUserAvatar(score.opponent).then((avatar) => {
-            if (avatar && avatar.type.startsWith('image/')) {
-              const avatarUrl = URL.createObjectURL(avatar);
-              opponentAvatarImg.src = avatarUrl;
-            } else {
-              opponentAvatarImg.src = `${API_URL}/media/default_avatar.png`;
-            }
-          });
-          opponentAvatarImg.alt = score.opponent;
-        }
-      }
-
-      if (playerScoreElement) playerScoreElement.textContent = String(score.player1);
-      if (opponentScoreElement) opponentScoreElement.textContent = String(score.player2);
-
-      if (resultMessage) {
-        if (score.disconnected) {
-          // 切断による勝敗表示
-          const wasDisconnected = score.disconnectedPlayer === username;
-          if (wasDisconnected) {
-            resultMessage.textContent = 'You Disconnected - Opponent Wins';
-            resultMessage.className = 'result-message lose';
-          } else {
-            resultMessage.textContent = 'Opponent Disconnected - You Win!';
-            resultMessage.className = 'result-message win';
-          }
-        } else {
-          // 通常のスコアによる勝敗表示
-          if (score.player1 > score.player2) {
-            resultMessage.textContent = 'You Win!';
-            resultMessage.className = 'result-message win';
-          } else if (score.player1 < score.player2) {
-            resultMessage.textContent = 'Opponent Wins!';
-            resultMessage.className = 'result-message lose';
-          } else {
-            resultMessage.textContent = 'Draw!';
-            resultMessage.className = 'result-message draw';
-          }
-        }
-      }
-
-      // 結果をバックエンドに送信
-      await sendGameResult(score, gameMode);
-
-      // スコアをクリア
-      localStorage.removeItem('finalScore');
-      localStorage.removeItem('gameMode');
+    if (!username) {
+      console.error('Username not found in local storage');
+      window.location.href = '/';
+      return;
     }
-
-    const exitBtn = document.getElementById('exitBtn');
-    exitBtn?.addEventListener('click', () => {
+    
+    // 結果データ取得
+    const resultData = GameResultService.getStoredResult();
+    if (!resultData) {
+      console.warn('No game result data found');
+      return;
+    }
+    
+    const { score, gameMode } = resultData;
+    
+    // UI初期化
+    const ui = new ResultPageUI();
+    
+    // 終了ボタン設定
+    ui.setupEventHandlers(() => {
       window.location.href = '/modes';
     });
+    
+    // 勝敗判定
+    const winnerInfo = GameResultService.determineWinner(score, username);
+    
+    // 画面表示更新
+    await ui.updateResultView(score, username, {
+      message: winnerInfo.message,
+      className: winnerInfo.className,
+    });
+    
+    // 結果をサーバーに送信
+    try {
+      await GameResultService.sendGameResult(score, gameMode);
+    } catch (error) {
+      console.error('Error saving game result:', error);
+    }
+    
+    // 保存データのクリア
+    GameResultService.clearStoredResult();
   },
 });
 


### PR DESCRIPTION
## 概要
リザルト画面でのデータの作成をフィックスします。

## 変更点
バックエンド（Django）

serializers.py

generate_session_id 関数の修正（プレイヤー名のソート、一意性の確保）
GameSerializer の create/update メソッド改修
セッションIDに基づく既存レコード検索・更新ロジックの追加


consumers.py

MatchmakingConsumer クラスの修正（マッチング時のゲームレコード作成）
セッションID生成を serializers.py と統一
マッチング時のセッションID配布方法の修正


views.py（または同等のゲーム結果受信API）

ゲーム結果更新用のエンドポイント追加または修正
プレイヤー権限チェック（誰が更新できるか）
重複更新の防止ロジック


models.py

Game モデルへの状態管理フィールド追加（必要に応じて）



フロントエンド（TypeScript）

models/Result/GameResultService.ts（リファクタリング後）または pages/Result/index.ts（元ファイル）

セッションID送信ロジックの追加
プレイヤーロールに基づく送信制御（player1のみが送信など）


models/MultiPlay/MultiplayerGameManager.ts

ゲームセッションIDの適切な保存
ゲーム終了時のロール判定（誰が結果を送信すべきか）


pages/MultiPlay/Waiting/index.ts

マッチメイキング時に受け取ったセッションIDの保存


pages/MultiPlay/Game/index.ts

ゲームセッションID処理の修正

## 影響範囲
特になし

## テスト
- http://10.16.3.4:8001/admin/pong/game/でゲーム結果が正しく保存できればおっけー（シングルプレイ、マルチプレイともに）

## 関連Issue
- 関連Issue: #150 
