### PR TITLE
FIX: ※2回め /resultのデータ修正 #150

### DIFF
--- a/frontend/src/models/Result/GameResultService.ts
+++ b/frontend/src/models/Result/GameResultService.ts
@@ -1,0 +1,200 @@
+// src/models/Result/GameResultService.ts
+import { API_URL } from '@/config/config';
+import { IGameResult, IGameMode } from '@/models/interface';
+
+/**
+ * ゲーム結果に関するサービスクラス
+ * バックエンドとの通信とゲーム結果データの管理を担当
+ */
+export class GameResultService {
+  /**
+   * ローカルストレージからゲーム結果を取得
+   */
+  static getStoredResult(): { score: IGameResult; gameMode: IGameMode } | null {
+    const storedScore = localStorage.getItem('finalScore');
+    const gameMode = (localStorage.getItem('gameMode') as IGameMode) || 'singleplayer';
+
+    if (!storedScore) return null;
+
+    try {
+      const score = JSON.parse(storedScore);
+      return { score, gameMode };
+    } catch (error) {
+      console.error('Failed to parse stored score:', error);
+      return null;
+    }
+  }
+
+  /**
+   * ローカルストレージからゲーム結果をクリア
+   */
+  static clearStoredResult(): void {
+    localStorage.removeItem('finalScore');
+    localStorage.removeItem('gameMode');
+  }
+
+  /**
+   * ゲームモードに基づいたAPIリクエストデータを構築
+   */
+  static buildGameData(score: IGameResult, gameMode: IGameMode, username: string): any {
+    // 基本データ構造
+    const baseData = {
+      status: 'COMPLETED',
+      end_time: new Date().toISOString(),
+    };
+
+    // ゲームモード別データ構築
+    if (gameMode === 'singleplayer') {
+      return {
+        ...baseData,
+        game_type: 'SINGLE',
+        player1: username,
+        player2: null,
+        score_player1: score.player1,
+        score_player2: score.player2,
+        is_ai_opponent: true,
+        winner: score.player1 > score.player2 ? username : null,
+      };
+    }
+
+    if (gameMode === 'multiplayer') {
+      const isWinner = score.player1 > score.player2;
+      const gameData = {
+        ...baseData,
+        game_type: 'MULTI',
+        player1: username,
+        player2: score.opponent,
+        score_player1: score.player1,
+        score_player2: score.player2,
+        is_ai_opponent: false,
+        winner: isWinner ? username : score.opponent,
+      };
+
+      // 切断情報処理
+      if (score.disconnected) {
+        gameData.winner = score.disconnectedPlayer === username ? score.opponent : username;
+      }
+
+      return gameData;
+    }
+
+    if (gameMode === 'tournament') {
+      // TODO: トーナメントモード用データ構築
+      return {
+        ...baseData,
+        game_type: 'TOURNAMENT',
+        // 他のトーナメント固有フィールド
+      };
+    }
+
+    return baseData;
+  }
+
+  /**
+   * ゲーム結果をバックエンドに送信
+   */
+  static async sendGameResult(score: IGameResult, gameMode: IGameMode): Promise<boolean> {
+    try {
+      const token = localStorage.getItem('token');
+      const username = localStorage.getItem('username');
+
+      if (!token || !username) {
+        console.error('Authentication data missing');
+        return false;
+      }
+
+      const gameData = this.buildGameData(score, gameMode, username);
+
+      // HTTPメソッドとエンドポイントの設定
+      // FIXME: これ全部PUTでいいのでは
+      let method = 'PUT'; // デフォルトは PUT
+      let endpoint = `${API_URL}/api/games/`;
+
+      if (gameMode === 'singleplayer') {
+        method = 'POST'; // シングルプレイヤーは POST
+      } else if (gameMode === 'multiplayer' && score.sessionId) {
+        // マルチプレイヤーでセッションIDがある場合、エンドポイントを変更
+        endpoint = `${API_URL}/api/games/session/${score.sessionId}/`;
+      }
+
+      const response = await fetch(endpoint, {
+        method: method,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Token ${token}`,
+        },
+        credentials: 'include',
+        body: JSON.stringify(gameData),
+      });
+
+      // デバッグログ
+      console.log('Request payload:', gameData);
+      console.log('Response status:', response.status);
+
+      const responseData = await response.json();
+      // NOTE: PUTが許可されていないと表示される
+      console.log('Response data:', responseData);
+
+      if (!response.ok) {
+        throw new Error(`API error: ${response.status}`);
+      }
+
+      console.log('Game result saved successfully');
+      return true;
+    } catch (error) {
+      console.error('Error saving game result:', error);
+      return false;
+    }
+  }
+
+  /**
+   * 勝者を判定
+   */
+  static determineWinner(
+    score: IGameResult,
+    username: string
+  ): {
+    isWinner: boolean;
+    message: string;
+    className: string;
+  } {
+    // 切断による勝敗
+    if (score.disconnected) {
+      const wasDisconnected = score.disconnectedPlayer === username;
+      if (wasDisconnected) {
+        return {
+          isWinner: false,
+          message: 'You Disconnected - Opponent Wins',
+          className: 'result-message lose',
+        };
+      } else {
+        return {
+          isWinner: true,
+          message: 'Opponent Disconnected - You Win!',
+          className: 'result-message win',
+        };
+      }
+    }
+
+    // 通常スコアによる勝敗
+    if (score.player1 > score.player2) {
+      return {
+        isWinner: true,
+        message: 'You Win!',
+        className: 'result-message win',
+      };
+    } else if (score.player1 < score.player2) {
+      return {
+        isWinner: false,
+        message: 'Opponent Wins!',
+        className: 'result-message lose',
+      };
+    } else {
+      return {
+        isWinner: false,
+        message: 'Draw!',
+        className: 'result-message draw',
+      };
+    }
+  }
+}

--- a/frontend/src/models/Result/GameResultService.ts
+++ b/frontend/src/models/Result/GameResultService.ts
@@ -1,22 +1,7 @@
 // src/models/Result/GameResultService.ts
 
 import { API_URL } from '@/config/config';
-
-/**
- * ゲーム結果データの型定義
- */
-export interface GameResultData {
-  player1: number;
-  player2: number;
-  opponent?: string;
-  disconnected?: boolean;
-  disconnectedPlayer?: string;
-}
-
-/**
- * ゲームモードの型定義
- */
-export type GameMode = 'singleplayer' | 'multiplayer' | 'tournament';
+import { IGameResult, IGameMode } from '@/models/interface';
 
 /**
  * ゲーム結果に関するサービスクラス
@@ -26,9 +11,9 @@ export class GameResultService {
   /**
    * ローカルストレージからゲーム結果を取得
    */
-  static getStoredResult(): { score: GameResultData; gameMode: GameMode } | null {
+  static getStoredResult(): { score: IGameResult; gameMode: IGameMode } | null {
     const storedScore = localStorage.getItem('finalScore');
-    const gameMode = localStorage.getItem('gameMode') as GameMode || 'singleplayer';
+    const gameMode = localStorage.getItem('gameMode') as IGameMode || 'singleplayer';
     
     if (!storedScore) return null;
     
@@ -52,7 +37,7 @@ export class GameResultService {
   /**
    * ゲームモードに基づいたAPIリクエストデータを構築
    */
-  static buildGameData(score: GameResultData, gameMode: GameMode, username: string): any {
+  static buildGameData(score: IGameResult, gameMode: IGameMode, username: string): any {
     // 基本データ構造
     const baseData = {
       status: 'COMPLETED',
@@ -109,7 +94,7 @@ export class GameResultService {
   /**
    * ゲーム結果をバックエンドに送信
    */
-  static async sendGameResult(score: GameResultData, gameMode: GameMode): Promise<boolean> {
+  static async sendGameResult(score: IGameResult, gameMode: IGameMode): Promise<boolean> {
     try {
       const token = localStorage.getItem('token');
       const username = localStorage.getItem('username');
@@ -153,7 +138,7 @@ export class GameResultService {
   /**
    * 勝者を判定
    */
-  static determineWinner(score: GameResultData, username: string): {
+  static determineWinner(score: IGameResult, username: string): {
     isWinner: boolean;
     message: string;
     className: string;

--- a/frontend/src/models/Result/ResultPageUI.ts
+++ b/frontend/src/models/Result/ResultPageUI.ts
@@ -1,0 +1,138 @@
+// src/models/Result/ResultPageUI.ts
+
+import { API_URL } from '@/config/config';
+import { fetchUserAvatar } from '@/models/User/repository';
+import { IGameResult } from '@/models/interface';
+
+/**
+ * 結果画面のUI操作を担当するクラス
+ */
+export class ResultPageUI {
+  private playerScoreElement: HTMLElement | null;
+  private opponentScoreElement: HTMLElement | null;
+  private resultMessage: HTMLElement | null;
+  private playerNameElement: HTMLElement | null;
+  private opponentNameElement: HTMLElement | null;
+  private playerAvatarImg: HTMLImageElement | null;
+  private opponentAvatarImg: HTMLImageElement | null;
+  private exitBtn: HTMLElement | null;
+
+  /**
+   * コンストラクタ - DOM要素の初期化
+   */
+  constructor() {
+    // スコア関連要素
+    this.playerScoreElement = document.getElementById('playerScore');
+    this.opponentScoreElement = document.getElementById('cpuScore');
+    this.resultMessage = document.getElementById('result-message');
+
+    // プレイヤー情報要素
+    this.playerNameElement = document.getElementById('playerName');
+    this.opponentNameElement = document.querySelector('.cpu-side .player-name');
+
+    // アバター要素
+    this.playerAvatarImg = document.getElementById('player-avatar') as HTMLImageElement;
+    this.opponentAvatarImg = document.getElementById('opponent-avatar') as HTMLImageElement;
+
+    // 操作ボタン
+    this.exitBtn = document.getElementById('exitBtn');
+  }
+
+  /**
+   * 終了ボタンのイベントハンドラを設定
+   */
+  setupEventHandlers(callback: () => void): void {
+    this.exitBtn?.addEventListener('click', callback);
+  }
+
+  /**
+   * プレイヤー名を表示
+   */
+  displayPlayerNames(username: string, opponent: string | undefined): void {
+    if (this.playerNameElement && username) {
+      this.playerNameElement.textContent = username;
+    }
+
+    if (this.opponentNameElement && opponent) {
+      this.opponentNameElement.textContent = opponent;
+    }
+  }
+
+  /**
+   * プレイヤーアバターを表示
+   */
+  async displayPlayerAvatars(username: string, opponent: string | undefined): Promise<void> {
+    if (!this.playerAvatarImg || !this.opponentAvatarImg) return;
+
+    // プレイヤーアバターの取得と表示
+    if (username) {
+      const avatar = await fetchUserAvatar(username);
+      if (avatar && avatar.type.startsWith('image/')) {
+        const avatarUrl = URL.createObjectURL(avatar);
+        this.playerAvatarImg.src = avatarUrl;
+      } else {
+        this.playerAvatarImg.src = `${API_URL}/media/default_avatar.png`;
+      }
+      this.playerAvatarImg.alt = username;
+    }
+
+    // 対戦相手アバターの取得と表示
+    if (opponent) {
+      const avatar = await fetchUserAvatar(opponent);
+      if (avatar && avatar.type.startsWith('image/')) {
+        const avatarUrl = URL.createObjectURL(avatar);
+        this.opponentAvatarImg.src = avatarUrl;
+      } else {
+        this.opponentAvatarImg.src = `${API_URL}/media/default_avatar.png`;
+      }
+      this.opponentAvatarImg.alt = opponent;
+    }
+  }
+
+  /**
+   * スコアを表示
+   */
+  displayScores(player1Score: number, player2Score: number): void {
+    if (this.playerScoreElement) {
+      this.playerScoreElement.textContent = String(player1Score);
+    }
+
+    if (this.opponentScoreElement) {
+      this.opponentScoreElement.textContent = String(player2Score);
+    }
+  }
+
+  /**
+   * 勝敗結果メッセージを表示
+   */
+  displayResultMessage(message: string, className: string): void {
+    if (this.resultMessage) {
+      this.resultMessage.textContent = message;
+      this.resultMessage.className = className;
+    }
+  }
+
+  /**
+   * 結果画面全体の更新
+   */
+  async updateResultView(
+    score: IGameResult,
+    username: string,
+    resultInfo: {
+      message: string;
+      className: string;
+    }
+  ): Promise<void> {
+    // スコア表示
+    this.displayScores(score.player1, score.player2);
+
+    // プレイヤー名表示
+    this.displayPlayerNames(username, score.opponent);
+
+    // アバター表示
+    await this.displayPlayerAvatars(username, score.opponent);
+
+    // 勝敗メッセージ表示
+    this.displayResultMessage(resultInfo.message, resultInfo.className);
+  }
+}

--- a/frontend/src/models/Result/ResultPageUI.ts
+++ b/frontend/src/models/Result/ResultPageUI.ts
@@ -2,7 +2,7 @@
 
 import { API_URL } from '@/config/config';
 import { fetchUserAvatar } from '@/models/User/repository';
-import { IGameResult } from '@/models/interface';
+import { GameResultData } from './GameResultService';
 
 /**
  * 結果画面のUI操作を担当するクラス
@@ -25,15 +25,15 @@ export class ResultPageUI {
     this.playerScoreElement = document.getElementById('playerScore');
     this.opponentScoreElement = document.getElementById('cpuScore');
     this.resultMessage = document.getElementById('result-message');
-
+    
     // プレイヤー情報要素
     this.playerNameElement = document.getElementById('playerName');
     this.opponentNameElement = document.querySelector('.cpu-side .player-name');
-
+    
     // アバター要素
     this.playerAvatarImg = document.getElementById('player-avatar') as HTMLImageElement;
     this.opponentAvatarImg = document.getElementById('opponent-avatar') as HTMLImageElement;
-
+    
     // 操作ボタン
     this.exitBtn = document.getElementById('exitBtn');
   }
@@ -96,7 +96,7 @@ export class ResultPageUI {
     if (this.playerScoreElement) {
       this.playerScoreElement.textContent = String(player1Score);
     }
-
+    
     if (this.opponentScoreElement) {
       this.opponentScoreElement.textContent = String(player2Score);
     }
@@ -115,23 +115,19 @@ export class ResultPageUI {
   /**
    * 結果画面全体の更新
    */
-  async updateResultView(
-    score: IGameResult,
-    username: string,
-    resultInfo: {
-      message: string;
-      className: string;
-    }
-  ): Promise<void> {
+  async updateResultView(score: GameResultData, username: string, resultInfo: {
+    message: string;
+    className: string;
+  }): Promise<void> {
     // スコア表示
     this.displayScores(score.player1, score.player2);
-
+    
     // プレイヤー名表示
     this.displayPlayerNames(username, score.opponent);
-
+    
     // アバター表示
     await this.displayPlayerAvatars(username, score.opponent);
-
+    
     // 勝敗メッセージ表示
     this.displayResultMessage(resultInfo.message, resultInfo.className);
   }

--- a/frontend/src/models/Result/test.ts
+++ b/frontend/src/models/Result/test.ts
@@ -1,0 +1,6 @@
+export class Test
+{
+    test() : void {
+        return;
+    }
+}

--- a/frontend/src/models/Result/test.ts
+++ b/frontend/src/models/Result/test.ts
@@ -1,6 +1,0 @@
-export class Test
-{
-    test() : void {
-        return;
-    }
-}

--- a/frontend/src/models/interface.ts
+++ b/frontend/src/models/interface.ts
@@ -24,6 +24,18 @@ export interface IRankingUser {
   level: number;
 }
 
+// ==== Result =====
+export interface IGameResult {
+  player1: number;
+  player2: number;
+  opponent?: string;
+  disconnected?: boolean;
+  disconnectedPlayer?: string;
+  sessionId?: string;
+}
+
+export type IGameMode = 'singleplayer' | 'multiplayer' | 'tournament';
+
 // ===== Game =====
 export interface IGameScore {
   player1: number;

--- a/frontend/src/pages/Result/index.ts
+++ b/frontend/src/pages/Result/index.ts
@@ -1,129 +1,67 @@
-import { API_URL } from '@/config/config';
+// frontend/src/pages/Result/index.ts
+
 import { Page } from '@/core/Page';
 import CommonLayout from '@/layouts/common/index';
-import { IGameScore } from '@/models/interface';
 import { checkUserAccess } from '@/models/User/auth';
-import { fetchUserAvatar } from '@/models/User/repository';
+import { GameResultService } from '@/models/Result/GameResultService';
+import { ResultPageUI } from '@/models/Result/ResultPageUI';
 
-async function sendGameResult(score: IGameScore) {
-  try {
-    const token = localStorage.getItem('token');
-    const username = localStorage.getItem('username');
-
-    // TODO: すべてのゲームモードで対応できるようにリファクタリングする
-    const gameData = {
-      player1: username,
-      player2: null,
-      score_player1: score.player1,
-      score_player2: score.player2,
-      is_ai_opponent: true,
-      winner: score.player1 > score.player2 ? username : null,
-      end_time: new Date().toISOString(),
-    };
-
-    const response = await fetch(`${API_URL}/api/games/`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Token ${token}`,
-      },
-      credentials: 'include',
-      body: JSON.stringify(gameData),
-    });
-
-    // デバッグ用のログを追加
-    console.log('Request payload:', gameData);
-    console.log('Response status:', response.status);
-    const responseData = await response.json();
-    console.log('Response data:', responseData);
-
-    if (!response.ok) {
-      throw new Error('Failed to save game result');
-    }
-
-    console.log('Game result saved successfully');
-  } catch (error) {
-    console.error('Error saving game result:', error);
-  }
-}
-
+/**
+ * 結果画面ページコンポーネント
+ * 全体のフローを制御し、各サービスを連携
+ */
 const ResultPage = new Page({
   name: 'Result',
   config: {
     layout: CommonLayout,
   },
   mounted: async ({ pg }: { pg: Page }): Promise<void> => {
+    // 認証チェック
     checkUserAccess();
-    const storedScore = localStorage.getItem('finalScore');
-    const gameMode = localStorage.getItem('gameMode');
+
+    // ユーザー名取得
     const username = localStorage.getItem('username');
-
-    if (storedScore && gameMode === 'multiplayer') {
-      const score = JSON.parse(storedScore);
-
-      // スコアの表示を更新
-      const playerScoreElement = document.getElementById('playerScore');
-      const opponentScoreElement = document.getElementById('cpuScore');
-      const resultMessage = document.getElementById('result-message');
-      const playerNameElement = document.getElementById('playerName');
-      const opponentNameElement = document.querySelector('.cpu-side .player-name');
-
-      if (playerNameElement && username) {
-        playerNameElement.textContent = username;
-      }
-
-      if (opponentNameElement && score.opponent) {
-        opponentNameElement.textContent = score.opponent;
-      }
-
-      const playerAvatarImg = document.getElementById('player-avatar') as HTMLImageElement;
-      const opponentAvatarImg = document.getElementById('opponent-avatar') as HTMLImageElement;
-      if (playerAvatarImg && opponentAvatarImg && username) {
-        fetchUserAvatar(username).then((avatar) => {
-          if (avatar && avatar.type.startsWith('image/')) {
-            const avatarUrl = URL.createObjectURL(avatar);
-            playerAvatarImg.src = avatarUrl;
-          } else {
-            playerAvatarImg.src = `${API_URL}/media/default_avatar.png`;
-          }
-        });
-        playerAvatarImg.alt = username;
-        fetchUserAvatar(score.opponent).then((avatar) => {
-          if (avatar && avatar.type.startsWith('image/')) {
-            const avatarUrl = URL.createObjectURL(avatar);
-            opponentAvatarImg.src = avatarUrl;
-          } else {
-            opponentAvatarImg.src = `${API_URL}/media/default_avatar.png`;
-          }
-        });
-        opponentAvatarImg.alt = score.opponent;
-      }
-
-      if (playerScoreElement) playerScoreElement.textContent = String(score.player1);
-      if (opponentScoreElement) opponentScoreElement.textContent = String(score.player2);
-
-      if (resultMessage) {
-        if (score.player1 > score.player2) {
-          resultMessage.textContent = 'You Win!';
-          resultMessage.className = 'result-message win';
-        } else {
-          resultMessage.textContent = 'Opponent Wins!';
-          resultMessage.className = 'result-message lose';
-        }
-      }
-
-      // 結果をバックエンドに送信
-      await sendGameResult(score);
-
-      // スコアをクリア
-      localStorage.removeItem('finalScore');
-      localStorage.removeItem('gameMode');
+    if (!username) {
+      console.error('Username not found in local storage');
+      window.location.href = '/';
+      return;
     }
 
-    const exitBtn = document.getElementById('exitBtn');
-    exitBtn?.addEventListener('click', () => {
+    // 結果データ取得
+    const resultData = GameResultService.getStoredResult();
+    if (!resultData) {
+      console.warn('No game result data found');
+      return;
+    }
+
+    const { score, gameMode } = resultData;
+
+    // UI初期化
+    const ui = new ResultPageUI();
+
+    // 終了ボタン設定
+    ui.setupEventHandlers(() => {
       window.location.href = '/modes';
     });
+
+    // 勝敗判定
+    const winnerInfo = GameResultService.determineWinner(score, username);
+
+    // 画面表示更新
+    await ui.updateResultView(score, username, {
+      message: winnerInfo.message,
+      className: winnerInfo.className,
+    });
+
+    // 結果をサーバーに送信
+    try {
+      await GameResultService.sendGameResult(score, gameMode);
+    } catch (error) {
+      console.error('Error saving game result:', error);
+    }
+
+    // 保存データのクリア
+    GameResultService.clearStoredResult();
   },
 });
 

--- a/frontend/src/pages/Result/index.ts
+++ b/frontend/src/pages/Result/index.ts
@@ -18,7 +18,7 @@ const ResultPage = new Page({
   mounted: async ({ pg }: { pg: Page }): Promise<void> => {
     // 認証チェック
     checkUserAccess();
-
+    
     // ユーザー名取得
     const username = localStorage.getItem('username');
     if (!username) {
@@ -26,40 +26,40 @@ const ResultPage = new Page({
       window.location.href = '/';
       return;
     }
-
+    
     // 結果データ取得
     const resultData = GameResultService.getStoredResult();
     if (!resultData) {
       console.warn('No game result data found');
       return;
     }
-
+    
     const { score, gameMode } = resultData;
-
+    
     // UI初期化
     const ui = new ResultPageUI();
-
+    
     // 終了ボタン設定
     ui.setupEventHandlers(() => {
       window.location.href = '/modes';
     });
-
+    
     // 勝敗判定
     const winnerInfo = GameResultService.determineWinner(score, username);
-
+    
     // 画面表示更新
     await ui.updateResultView(score, username, {
       message: winnerInfo.message,
       className: winnerInfo.className,
     });
-
+    
     // 結果をサーバーに送信
     try {
       await GameResultService.sendGameResult(score, gameMode);
     } catch (error) {
       console.error('Error saving game result:', error);
     }
-
+    
     // 保存データのクリア
     GameResultService.clearStoredResult();
   },


### PR DESCRIPTION
## 概要
resultページのリファクタリング

## 変更点
Resultページ関連

## 影響範囲
TODO:

## テスト

- リザルトページまで正しく表示される
- localhost:5433にアクセスしてpong.gameテーブルにレコードが追加される
※既知のバグとしてレコードが2件同時に登録されてしまうので、別イシューで対応想定
## 関連Issue
- 関連Issue: #150 