### PR TITLE
ADD: トーナメント機能の完成まで #212

### DIFF
--- a/api/pong/routing.py
+++ b/api/pong/routing.py
@@ -20,7 +20,7 @@ websocket_urlpatterns = [
         TournamentGameConsumer.as_asgi(),
     ),
     re_path(
-        r"ws/tournament/waiting_final/(?P<session_id>[^/]+)/(?P<username>[^/]+)/$",
+        r"ws/tournament/waiting_final/(?P<tournament_id>[^/]+)/(?P<username>[^/]+)/$",
         TournamentWaitingFinalConsumer.as_asgi(),
     ),
 ]

--- a/api/pong/tournament_consumers.py
+++ b/api/pong/tournament_consumers.py
@@ -188,7 +188,7 @@ class TournamentGameConsumer(BaseGameConsumer):
                         break
 
                 await asyncio.sleep(0.016)
-                
+
         except asyncio.CancelledError:
             # ループのキャンセル（クリーンアップ）
             pass
@@ -199,7 +199,6 @@ class TournamentGameConsumer(BaseGameConsumer):
         if self.session_id in self.games:
             del self.games[self.session_id]
             print(f"Game instance removed for session {self.session_id}")
-
 
     @database_sync_to_async
     def get_or_create_tournament_game(self):
@@ -762,30 +761,36 @@ class TournamentMatchmakingConsumer(AsyncWebsocketConsumer):
 
 class TournamentWaitingFinalConsumer(AsyncWebsocketConsumer):
     """決勝戦開始を待機するプレイヤー向けのWebSocketコンシューマ
-    
     URL: /ws/tournament/waiting_final/{tournament_id}/{username}/
     """
+
     async def connect(self):
         """WebSocket接続時の処理"""
         # URLパラメータの取得
-        self.tournament_id = self.scope["url_route"]["kwargs"].get("session_id", "")
+        self.tournament_id = self.scope["url_route"]["kwargs"].get("tournament_id", "")
         self.username = self.scope["url_route"]["kwargs"].get("username", "")
 
         # トーナメント待機グループに参加
         self.group_name = f"tournament_final_waiting_{self.tournament_id}"
         await self.channel_layer.group_add(self.group_name, self.channel_name)
-        
+
         # 接続を受け入れる
         await self.accept()
-        print(f"Player {self.username} connected to tournament final waiting for tournament {self.tournament_id}")
-        
+        print(
+            f"Player {self.username} connected to tournament final waiting for tournament {self.tournament_id}"
+        )
+
         # 参加資格検証（準決勝勝者かどうか）
         is_eligible = await self.verify_eligibility()
         if not is_eligible:
-            await self.send(text_data=json.dumps({
-                "type": "error",
-                "message": "You are not eligible for the final match."
-            }))
+            await self.send(
+                text_data=json.dumps(
+                    {
+                        "type": "error",
+                        "message": "You are not eligible for the final match.",
+                    }
+                )
+            )
             # 接続を閉じる（資格のないユーザー）
             await self.close()
             return
@@ -801,26 +806,24 @@ class TournamentWaitingFinalConsumer(AsyncWebsocketConsumer):
         try:
             data = json.loads(text_data)
             message_type = data.get("type")
-            
+
             # ステータス要求メッセージの処理
             if message_type == "request_status":
                 status_data = await self.get_waiting_status()
                 await self.send(text_data=json.dumps(status_data))
-                
+
                 # 両方の準決勝が完了していれば決勝戦の準備
                 if status_data.get("all_semifinals_completed", False):
                     await self.check_and_prepare_final()
-        
+
         except json.JSONDecodeError:
-            await self.send(text_data=json.dumps({
-                "type": "error",
-                "message": "Invalid JSON format"
-            }))
+            await self.send(
+                text_data=json.dumps(
+                    {"type": "error", "message": "Invalid JSON format"}
+                )
+            )
         except Exception as e:
-            await self.send(text_data=json.dumps({
-                "type": "error",
-                "message": str(e)
-            }))
+            await self.send(text_data=json.dumps({"type": "error", "message": str(e)}))
 
     @database_sync_to_async
     def verify_eligibility(self):
@@ -829,14 +832,14 @@ class TournamentWaitingFinalConsumer(AsyncWebsocketConsumer):
             # トーナメント情報の取得
             tournament = TournamentSession.objects.get(id=self.tournament_id)
             user = User.objects.get(username=self.username)
-            
+
             # ブラケット位置が5（決勝進出者）のプレイヤーであるか確認
             participant = TournamentParticipant.objects.filter(
                 tournament=tournament,
                 user=user,
-                bracket_position=5  # 決勝進出者の位置
+                bracket_position=5,  # 決勝進出者の位置
             ).exists()
-            
+
             return participant
         except (TournamentSession.DoesNotExist, User.DoesNotExist):
             return False
@@ -849,53 +852,52 @@ class TournamentWaitingFinalConsumer(AsyncWebsocketConsumer):
         """決勝待機ステータスの取得"""
         try:
             tournament = TournamentSession.objects.get(id=self.tournament_id)
-            
+
             # 準決勝の完了数をカウント
             completed_semifinals = Game.objects.filter(
                 tournament=tournament,
                 tournament_round=0,  # 準決勝
-                status="COMPLETED"
+                status="COMPLETED",
             ).count()
-            
+
             # 決勝進出者リスト
             finalists = []
             for participant in TournamentParticipant.objects.filter(
                 tournament=tournament,
-                bracket_position=5  # 決勝進出者
+                bracket_position=5,  # 決勝進出者
             ).select_related("user"):
-                finalists.append({
-                    "username": participant.user.username,
-                    "display_name": participant.user.display_name
-                })
-            
+                finalists.append(
+                    {
+                        "username": participant.user.username,
+                        "display_name": participant.user.display_name,
+                    }
+                )
+
             # 全準決勝完了フラグ
             all_semifinals_completed = completed_semifinals == 2
-            
+
             return {
                 "type": "waiting_status",
                 "tournament_id": self.tournament_id,
                 "completed_semifinals": completed_semifinals,
                 "all_semifinals_completed": all_semifinals_completed,
                 "finalists": finalists,
-                "timestamp": timezone.now().timestamp()
+                "timestamp": timezone.now().timestamp(),
             }
         except Exception as e:
             print(f"Error getting waiting status: {e}")
-            return {
-                "type": "error",
-                "message": f"Error getting status: {str(e)}"
-            }
+            return {"type": "error", "message": f"Error getting status: {str(e)}"}
 
     async def check_and_prepare_final(self):
         """決勝戦の準備が整っているか確認し、準備"""
         try:
             # 決勝戦情報の取得
             final_match = await self.get_final_match()
-            
+
             if not final_match:
                 print("Final match not found or not ready")
                 return
-            
+
             # 決勝戦の準備が整っている場合、参加プレイヤーに通知
             await self.channel_layer.group_send(
                 self.group_name,
@@ -903,8 +905,8 @@ class TournamentWaitingFinalConsumer(AsyncWebsocketConsumer):
                     "type": "final_ready",
                     "session_id": final_match["session_id"],
                     "player1": final_match["player1"],
-                    "player2": final_match["player2"]
-                }
+                    "player2": final_match["player2"],
+                },
             )
         except Exception as e:
             print(f"Error checking and preparing final: {e}")
@@ -914,22 +916,22 @@ class TournamentWaitingFinalConsumer(AsyncWebsocketConsumer):
         """決勝戦情報の取得"""
         try:
             tournament = TournamentSession.objects.get(id=self.tournament_id)
-            
+
             # 決勝戦の取得
             final_match = Game.objects.filter(
                 tournament=tournament,
                 tournament_round=1,  # 決勝
-                status__in=["WAITING", "IN_PROGRESS"]
+                status__in=["WAITING", "IN_PROGRESS"],
             ).first()
-            
+
             if not final_match:
                 return None
-            
+
             return {
                 "session_id": final_match.session_id,
                 "player1": final_match.player1.username,
                 "player2": final_match.player2.username,
-                "status": final_match.status
+                "status": final_match.status,
             }
         except Exception as e:
             print(f"Error getting final match: {e}")
@@ -939,10 +941,14 @@ class TournamentWaitingFinalConsumer(AsyncWebsocketConsumer):
         """決勝戦準備完了通知のハンドラー"""
         # プレイヤー1か2かを判定
         is_player1 = self.username == event["player1"]
-        
+
         # クライアントに通知
-        await self.send(text_data=json.dumps({
-            "type": "final_ready",
-            "session_id": event["session_id"],
-            "is_player1": is_player1
-        }))  
+        await self.send(
+            text_data=json.dumps(
+                {
+                    "type": "final_ready",
+                    "session_id": event["session_id"],
+                    "is_player1": is_player1,
+                }
+            )
+        )

--- a/api/pong/tournament_consumers.py
+++ b/api/pong/tournament_consumers.py
@@ -735,17 +735,189 @@ class TournamentMatchmakingConsumer(AsyncWebsocketConsumer):
             await self.send(text_data=json.dumps(event["message"]))
 
 
-# TODO
 class TournamentWaitingFinalConsumer(AsyncWebsocketConsumer):
-    """決勝戦開始を待機するプレイヤー向けのWebSocketコンシューマ"""
-
+    """決勝戦開始を待機するプレイヤー向けのWebSocketコンシューマ
+    
+    URL: /ws/tournament/waiting_final/{tournament_id}/{username}/
+    """
     async def connect(self):
-        return
+        """WebSocket接続時の処理"""
+        # URLパラメータの取得
+        self.tournament_id = self.scope["url_route"]["kwargs"].get("session_id", "")
+        self.username = self.scope["url_route"]["kwargs"].get("username", "")
+
+        # トーナメント待機グループに参加
+        self.group_name = f"tournament_final_waiting_{self.tournament_id}"
+        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        
+        # 接続を受け入れる
+        await self.accept()
+        print(f"Player {self.username} connected to tournament final waiting for tournament {self.tournament_id}")
+        
+        # 参加資格検証（準決勝勝者かどうか）
+        is_eligible = await self.verify_eligibility()
+        if not is_eligible:
+            await self.send(text_data=json.dumps({
+                "type": "error",
+                "message": "You are not eligible for the final match."
+            }))
+            # 接続を閉じる（資格のないユーザー）
+            await self.close()
+            return
 
     async def disconnect(self, close_code):
-        # グループからの離脱
-        return
+        """WebSocket切断時の処理"""
+        # グループから離脱
+        await self.channel_layer.group_discard(self.group_name, self.channel_name)
+        print(f"Player {self.username} disconnected from tournament final waiting")
 
     async def receive(self, text_data):
         """クライアントからのメッセージ受信処理"""
-        return
+        try:
+            data = json.loads(text_data)
+            message_type = data.get("type")
+            
+            # ステータス要求メッセージの処理
+            if message_type == "request_status":
+                status_data = await self.get_waiting_status()
+                await self.send(text_data=json.dumps(status_data))
+                
+                # 両方の準決勝が完了していれば決勝戦の準備
+                if status_data.get("all_semifinals_completed", False):
+                    await self.check_and_prepare_final()
+        
+        except json.JSONDecodeError:
+            await self.send(text_data=json.dumps({
+                "type": "error",
+                "message": "Invalid JSON format"
+            }))
+        except Exception as e:
+            await self.send(text_data=json.dumps({
+                "type": "error",
+                "message": str(e)
+            }))
+
+    @database_sync_to_async
+    def verify_eligibility(self):
+        """ユーザーが決勝戦に参加する資格があるか検証"""
+        try:
+            # トーナメント情報の取得
+            tournament = TournamentSession.objects.get(id=self.tournament_id)
+            user = User.objects.get(username=self.username)
+            
+            # ブラケット位置が5（決勝進出者）のプレイヤーであるか確認
+            participant = TournamentParticipant.objects.filter(
+                tournament=tournament,
+                user=user,
+                bracket_position=5  # 決勝進出者の位置
+            ).exists()
+            
+            return participant
+        except (TournamentSession.DoesNotExist, User.DoesNotExist):
+            return False
+        except Exception as e:
+            print(f"Error verifying eligibility: {e}")
+            return False
+
+    @database_sync_to_async
+    def get_waiting_status(self):
+        """決勝待機ステータスの取得"""
+        try:
+            tournament = TournamentSession.objects.get(id=self.tournament_id)
+            
+            # 準決勝の完了数をカウント
+            completed_semifinals = Game.objects.filter(
+                tournament=tournament,
+                tournament_round=0,  # 準決勝
+                status="COMPLETED"
+            ).count()
+            
+            # 決勝進出者リスト
+            finalists = []
+            for participant in TournamentParticipant.objects.filter(
+                tournament=tournament,
+                bracket_position=5  # 決勝進出者
+            ).select_related("user"):
+                finalists.append({
+                    "username": participant.user.username,
+                    "display_name": participant.user.display_name
+                })
+            
+            # 全準決勝完了フラグ
+            all_semifinals_completed = completed_semifinals == 2
+            
+            return {
+                "type": "waiting_status",
+                "tournament_id": self.tournament_id,
+                "completed_semifinals": completed_semifinals,
+                "all_semifinals_completed": all_semifinals_completed,
+                "finalists": finalists,
+                "timestamp": timezone.now().timestamp()
+            }
+        except Exception as e:
+            print(f"Error getting waiting status: {e}")
+            return {
+                "type": "error",
+                "message": f"Error getting status: {str(e)}"
+            }
+
+    async def check_and_prepare_final(self):
+        """決勝戦の準備が整っているか確認し、準備"""
+        try:
+            # 決勝戦情報の取得
+            final_match = await self.get_final_match()
+            
+            if not final_match:
+                print("Final match not found or not ready")
+                return
+            
+            # 決勝戦の準備が整っている場合、参加プレイヤーに通知
+            await self.channel_layer.group_send(
+                self.group_name,
+                {
+                    "type": "final_ready",
+                    "session_id": final_match["session_id"],
+                    "player1": final_match["player1"],
+                    "player2": final_match["player2"]
+                }
+            )
+        except Exception as e:
+            print(f"Error checking and preparing final: {e}")
+
+    @database_sync_to_async
+    def get_final_match(self):
+        """決勝戦情報の取得"""
+        try:
+            tournament = TournamentSession.objects.get(id=self.tournament_id)
+            
+            # 決勝戦の取得
+            final_match = Game.objects.filter(
+                tournament=tournament,
+                tournament_round=1,  # 決勝
+                status__in=["WAITING", "IN_PROGRESS"]
+            ).first()
+            
+            if not final_match:
+                return None
+            
+            return {
+                "session_id": final_match.session_id,
+                "player1": final_match.player1.username,
+                "player2": final_match.player2.username,
+                "status": final_match.status
+            }
+        except Exception as e:
+            print(f"Error getting final match: {e}")
+            return None
+
+    async def final_ready(self, event):
+        """決勝戦準備完了通知のハンドラー"""
+        # プレイヤー1か2かを判定
+        is_player1 = self.username == event["player1"]
+        
+        # クライアントに通知
+        await self.send(text_data=json.dumps({
+            "type": "final_ready",
+            "session_id": event["session_id"],
+            "is_player1": is_player1
+        }))  

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -18,6 +18,7 @@ import SettingsUserPage from './pages/Settings/User/index';
 import TournamentPage from './pages/Tournament';
 import TournamentWaitingPage from './pages/Tournament/Waiting';
 import TournamentGamePage from './pages/Tournament/Game/index';
+import TournamentWaitingNextMatchPage from './pages/Tournament/WaitingNextMatch';
 
 import { Page } from './core/Page';
 import { ICurrentUser } from './libs/Auth/currnetUser';
@@ -47,6 +48,7 @@ const routes: Record<string, Page> = {
   '/tournament': TournamentPage,
   '/tournament/waiting': TournamentWaitingPage,
   '/tournament/game': TournamentGamePage,
+  '/tournament/waiting-next-match': TournamentWaitingNextMatchPage,
   '/leaderboard': LeaderboardPage,
   '/friends': FriendsPage,
 };

--- a/frontend/src/models/Tournament/TournamentGameManager.ts
+++ b/frontend/src/models/Tournament/TournamentGameManager.ts
@@ -2,8 +2,7 @@
 import { BaseGameManager } from '@/models/Services/BaseGameManager';
 import { GameRenderer } from '@/models/Services/game_renderer';
 import { IGameConfig, IGameState, ITournamentInfo } from '@/models/Game/type';
-import { logger } from '@/core/Logger'
-
+import { logger } from '@/core/Logger';
 
 export class TournamentGameManager extends BaseGameManager {
   private renderer: GameRenderer;

--- a/frontend/src/pages/Tournament/Game/index.ts
+++ b/frontend/src/pages/Tournament/Game/index.ts
@@ -2,7 +2,7 @@
 import { WS_URL } from '@/config/config';
 import { Page } from '@/core/Page';
 import AuthLayout from '@/layouts/AuthLayout';
-import { logger } from '@/core/Logger'
+import { logger } from '@/core/Logger';
 import { IGameConfig } from '@/models/Game/type';
 import { TournamentGameManager } from '@/models/Tournament/TournamentGameManager';
 

--- a/frontend/src/pages/Tournament/Game/index.ts
+++ b/frontend/src/pages/Tournament/Game/index.ts
@@ -2,6 +2,7 @@
 import { WS_URL } from '@/config/config';
 import { Page } from '@/core/Page';
 import AuthLayout from '@/layouts/AuthLayout';
+import { logger } from '@/core/Logger'
 import { IGameConfig } from '@/models/Game/type';
 import { TournamentGameManager } from '@/models/Tournament/TournamentGameManager';
 
@@ -12,7 +13,7 @@ const GamePage = new Page({
     html: '/src/pages/Tournament/Game/index.html',
   },
   mounted: async ({ pg, user }) => {
-    console.log('Tournament Game page mounting...');
+    logger.info('Tournament Game page mounting...');
 
     // URLパラメータの取得と検証
     const urlParams = new URLSearchParams(window.location.search);
@@ -23,7 +24,7 @@ const GamePage = new Page({
     const isPlayer1 = urlParams.get('isPlayer1') === 'true';
     const username = user.username;
 
-    console.log('Tournament game parameters:', {
+    logger.info('Tournament game parameters:', {
       tournamentId,
       roundType,
       matchNumber,
@@ -73,14 +74,14 @@ const GamePage = new Page({
 
       // ゲーム開始
       await gameManager.init();
-      console.log('Tournament game initialized successfully');
+      logger.info('Tournament game initialized successfully');
 
       // タイトル更新
       document.title = `Tournament ${roundType.startsWith('semi') ? 'Semi-Final' : 'Final'}`;
 
       // クリーンアップ関数を返す
       return () => {
-        console.log('Tournament game page unmounting, cleaning up resources...');
+        logger.info('Tournament game page unmounting, cleaning up resources...');
         gameManager.cleanup();
       };
     } catch (error) {

--- a/frontend/src/pages/Tournament/Waiting/index.ts
+++ b/frontend/src/pages/Tournament/Waiting/index.ts
@@ -1,6 +1,7 @@
 // frontend/src/pages/Tournament/Waiting/index.ts
 import { WS_URL } from '@/config/config';
 import { Page } from '@/core/Page';
+import { logger } from '@/core/Logger';
 import AuthLayout from '@/layouts/AuthLayout';
 import { API_URL } from '@/config/config';
 
@@ -11,7 +12,7 @@ const WaitingPage = new Page({
     html: '/src/pages/Tournament/Waiting/index.html',
   },
   mounted: async ({ pg, user }) => {
-    console.log('Tournament waiting page - initializing');
+    logger.info('Tournament waiting page - initializing');
 
     // DOM要素の取得
     const connectionStatus = document.getElementById('connection-status');
@@ -26,7 +27,7 @@ const WaitingPage = new Page({
     const handleSocketMessage = (event: MessageEvent) => {
       try {
         const data = JSON.parse(event.data);
-        console.log('Received websocket message:', data);
+        logger.info('Received websocket message:', data);
 
         switch (data.type) {
           case 'error':
@@ -42,7 +43,7 @@ const WaitingPage = new Page({
             break;
         }
       } catch (e) {
-        console.error('Error parsing message:', e);
+        logger.info('Error parsing message:', e);
       }
     };
 
@@ -80,7 +81,7 @@ const WaitingPage = new Page({
 
     // マッチ発見時の処理
     const handleMatchFound = (data: any) => {
-      console.log('Match found!', data);
+      logger.info('Match found!', data);
 
       if (connectionStatus) {
         connectionStatus.textContent = 'Match found! Redirecting to game...';
@@ -102,7 +103,7 @@ const WaitingPage = new Page({
       socket = new WebSocket(`${WS_URL}/ws/tournament/`);
 
       socket.onopen = () => {
-        console.log('WebSocket connection established');
+        logger.info('WebSocket connection established');
 
         // トーナメント参加メッセージの送信
         socket.send(
@@ -120,14 +121,14 @@ const WaitingPage = new Page({
       socket.onmessage = handleSocketMessage;
 
       socket.onerror = (error) => {
-        console.error('WebSocket error:', error);
+        logger.error('WebSocket error:', error);
         if (connectionStatus) {
           connectionStatus.textContent = 'Connection error. Retrying...';
         }
       };
 
       socket.onclose = () => {
-        console.log('WebSocket connection closed');
+        logger.info('WebSocket connection closed');
         if (connectionStatus) {
           connectionStatus.textContent = 'Connection lost. Reconnecting...';
         }

--- a/frontend/src/pages/Tournament/WaitingNextMatch/index.html
+++ b/frontend/src/pages/Tournament/WaitingNextMatch/index.html
@@ -1,17 +1,34 @@
-<div class="container mt-5">
-  <div class="row justify-content-center">
-    <div class="col-md-8">
-      <div class="card">
-        <div class="card-header">
-          <h2 class="text-center">Waiting for Final Match</h2>
-        </div>
-        <div class="card-body">
-          <p class="text-center">Tournament final match functionality is currently under redevelopment.</p>
-          <div class="d-flex justify-content-center">
-            <button id="back-button" class="btn btn-primary">Back to Tournament</button>
-          </div>
-        </div>
+<!-- frontend/src/pages/Tournament/WaitingNextMatch/index.html -->
+<div class="container waiting-container">
+  <div class="waiting-box">
+    <h1 class="waiting-title">Waiting for Final Match</h1>
+    
+    <div class="status-section">
+      <div class="loading-spinner"></div>
+      <p id="status-message">Waiting for other semi-final to complete...</p>
+      <div id="player-status">
+        <span id="completed-count">1</span>/2 semi-finals completed
       </div>
+    </div>
+    
+    <div class="players-section">
+      <h3>Finalists</h3>
+      <ul id="finalists-container" class="players-list">
+        <!-- 決勝進出プレイヤーがここに表示されます -->
+        <li class="player-item you">
+          <span class="player-tag">YOU</span>
+          <span class="player-name" id="your-name">Your Name</span>
+          <span class="status-tag ready">Ready</span>
+        </li>
+        <li class="player-item waiting">
+          <span class="player-name">Waiting for opponent...</span>
+          <span class="status-tag waiting">Waiting</span>
+        </li>
+      </ul>
+    </div>
+    
+    <div class="actions-section">
+      <button id="cancel-button" class="cancel-button">Return to Tournament</button>
     </div>
   </div>
 </div>

--- a/frontend/src/pages/Tournament/WaitingNextMatch/index.ts
+++ b/frontend/src/pages/Tournament/WaitingNextMatch/index.ts
@@ -1,6 +1,7 @@
 // frontend/src/pages/Tournament/WaitingNextMatch/index.ts
 import { WS_URL } from '@/config/config';
 import { Page } from '@/core/Page';
+import { logger } from '@/core/Logger';
 import AuthLayout from '@/layouts/AuthLayout';
 
 const WaitingNextMatchPage = new Page({
@@ -10,14 +11,14 @@ const WaitingNextMatchPage = new Page({
     html: '/src/pages/Tournament/WaitingNextMatch/index.html',
   },
   mounted: async ({ pg, user }) => {
-    console.log('Tournament waiting next match page mounting...');
+    logger.info('Tournament waiting next match page mounting...');
     
     // URLパラメーターの取得
     const urlParams = new URLSearchParams(window.location.search);
     const tournamentId = urlParams.get('tournamentId');
     
     if (!tournamentId) {
-      console.error('Tournament ID not provided');
+      logger.error('Tournament ID not provided');
       window.location.href = '/tournament';
       return;
     }
@@ -57,7 +58,7 @@ const WaitingNextMatchPage = new Page({
       socket = new WebSocket(wsEndpoint);
       
       socket.onopen = () => {
-        console.log('Connected to waiting final WebSocket');
+        logger.info('Connected to waiting final WebSocket');
         if (statusMessage) {
           statusMessage.textContent = 'Connected. Waiting for other semi-final to complete...';
         }
@@ -73,7 +74,7 @@ const WaitingNextMatchPage = new Page({
       socket.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
-          console.log('Received message:', data);
+          logger.info('Received message:', data);
           
           switch (data.type) {
             case 'waiting_status':
@@ -91,19 +92,19 @@ const WaitingNextMatchPage = new Page({
               break;
           }
         } catch (e) {
-          console.error('Error parsing WebSocket message:', e);
+          logger.error('Error parsing WebSocket message:', e);
         }
       };
       
       socket.onerror = (error) => {
-        console.error('WebSocket error:', error);
+        logger.error('WebSocket error:', error);
         if (statusMessage) {
           statusMessage.textContent = 'Connection error. Retrying...';
         }
       };
       
       socket.onclose = (event) => {
-        console.log('WebSocket closed:', event);
+        logger.info('WebSocket closed:', event);
         if (statusMessage) {
           statusMessage.textContent = 'Connection lost. Reconnecting...';
         }
@@ -187,7 +188,7 @@ const WaitingNextMatchPage = new Page({
     
     // ページアンマウント時のクリーンアップ
     return () => {
-      console.log('Tournament waiting next match page unmounting...');
+      logger.info('Tournament waiting next match page unmounting...');
       if (reconnectTimeout) {
         window.clearTimeout(reconnectTimeout);
       }

--- a/frontend/src/pages/Tournament/WaitingNextMatch/index.ts
+++ b/frontend/src/pages/Tournament/WaitingNextMatch/index.ts
@@ -1,3 +1,5 @@
+// frontend/src/pages/Tournament/WaitingNextMatch/index.ts
+import { WS_URL } from '@/config/config';
 import { Page } from '@/core/Page';
 import AuthLayout from '@/layouts/AuthLayout';
 
@@ -8,15 +10,191 @@ const WaitingNextMatchPage = new Page({
     html: '/src/pages/Tournament/WaitingNextMatch/index.html',
   },
   mounted: async ({ pg, user }) => {
-    console.log('Tournament waiting next match page - placeholder implementation');
-
-    // 戻るボタンの機能だけ実装しておく
-    const backButton = document.getElementById('back-button');
-    if (backButton) {
-      backButton.addEventListener('click', () => {
+    console.log('Tournament waiting next match page mounting...');
+    
+    // URLパラメーターの取得
+    const urlParams = new URLSearchParams(window.location.search);
+    const tournamentId = urlParams.get('tournamentId');
+    
+    if (!tournamentId) {
+      console.error('Tournament ID not provided');
+      window.location.href = '/tournament';
+      return;
+    }
+    
+    // DOM要素の取得
+    const statusMessage = document.getElementById('status-message');
+    const completedCount = document.getElementById('completed-count');
+    const yourName = document.getElementById('your-name');
+    const finalistsContainer = document.getElementById('finalists-container');
+    const cancelButton = document.getElementById('cancel-button');
+    
+    // 現在のユーザー名を表示
+    if (yourName && user.username) {
+      yourName.textContent = user.display_name || user.username;
+    }
+    
+    // キャンセルボタンのイベントリスナー
+    if (cancelButton) {
+      cancelButton.addEventListener('click', () => {
+        if (socket) socket.close();
         window.location.href = '/tournament';
       });
     }
+    
+    // WebSocket接続変数
+    let socket: WebSocket | null = null;
+    let reconnectTimeout: number | null = null;
+    
+    // WebSocket接続関数
+    const connectWebSocket = () => {
+      if (socket) {
+        socket.close();
+      }
+      
+      const wsEndpoint = `${WS_URL}/ws/tournament/waiting_final/${tournamentId}/${user.username}/`;
+      
+      socket = new WebSocket(wsEndpoint);
+      
+      socket.onopen = () => {
+        console.log('Connected to waiting final WebSocket');
+        if (statusMessage) {
+          statusMessage.textContent = 'Connected. Waiting for other semi-final to complete...';
+        }
+        
+        // 接続成功時にステータス要求メッセージを送信
+        socket.send(JSON.stringify({
+          type: 'request_status',
+          tournament_id: tournamentId,
+          username: user.username
+        }));
+      };
+      
+      socket.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          console.log('Received message:', data);
+          
+          switch (data.type) {
+            case 'waiting_status':
+              updateWaitingStatus(data);
+              break;
+              
+            case 'final_ready':
+              handleFinalReady(data);
+              break;
+              
+            case 'error':
+              if (statusMessage) {
+                statusMessage.textContent = `Error: ${data.message}`;
+              }
+              break;
+          }
+        } catch (e) {
+          console.error('Error parsing WebSocket message:', e);
+        }
+      };
+      
+      socket.onerror = (error) => {
+        console.error('WebSocket error:', error);
+        if (statusMessage) {
+          statusMessage.textContent = 'Connection error. Retrying...';
+        }
+      };
+      
+      socket.onclose = (event) => {
+        console.log('WebSocket closed:', event);
+        if (statusMessage) {
+          statusMessage.textContent = 'Connection lost. Reconnecting...';
+        }
+        
+        // 再接続を試行（5秒後）
+        if (reconnectTimeout) {
+          window.clearTimeout(reconnectTimeout);
+        }
+        reconnectTimeout = window.setTimeout(connectWebSocket, 5000);
+      };
+    };
+    
+    // 待機ステータス更新
+    const updateWaitingStatus = (data: any) => {
+      if (completedCount) {
+        completedCount.textContent = data.completed_semifinals.toString();
+      }
+      
+      if (finalistsContainer) {
+        // 既存のリストをクリア
+        finalistsContainer.innerHTML = '';
+        
+        // 自分自身のエントリーを追加
+        const selfItem = document.createElement('li');
+        selfItem.className = 'player-item you';
+        selfItem.innerHTML = `
+          <span class="player-tag">YOU</span>
+          <span class="player-name">${user.display_name || user.username}</span>
+          <span class="status-tag ready">Ready</span>
+        `;
+        finalistsContainer.appendChild(selfItem);
+        
+        // 他の決勝進出者（いる場合）
+        if (data.finalists && data.finalists.length > 0) {
+          data.finalists.forEach((finalist: any) => {
+            if (finalist.username !== user.username) {
+              const finalistItem = document.createElement('li');
+              finalistItem.className = 'player-item';
+              finalistItem.innerHTML = `
+                <span class="player-name">${finalist.display_name || finalist.username}</span>
+                <span class="status-tag ready">Ready</span>
+              `;
+              finalistsContainer.appendChild(finalistItem);
+            }
+          });
+        } else {
+          // 他の決勝進出者がまだいない場合
+          const waitingItem = document.createElement('li');
+          waitingItem.className = 'player-item waiting';
+          waitingItem.innerHTML = `
+            <span class="player-name">Waiting for opponent...</span>
+            <span class="status-tag waiting">Waiting</span>
+          `;
+          finalistsContainer.appendChild(waitingItem);
+        }
+      }
+      
+      if (statusMessage) {
+        if (data.all_semifinals_completed) {
+          statusMessage.textContent = 'All semi-finals completed. Preparing final match...';
+        } else {
+          statusMessage.textContent = 'Waiting for other semi-final to complete...';
+        }
+      }
+    };
+    
+    // 決勝戦準備完了処理
+    const handleFinalReady = (data: any) => {
+      if (statusMessage) {
+        statusMessage.textContent = 'Final match is ready! Redirecting...';
+      }
+      
+      // 決勝戦ページへリダイレクト
+      setTimeout(() => {
+        window.location.href = `/tournament/game?tournamentId=${tournamentId}&round=final&session=${data.session_id}&isPlayer1=${data.is_player1}`;
+      }, 2000);
+    };
+    
+    // WebSocket接続開始
+    connectWebSocket();
+    
+    // ページアンマウント時のクリーンアップ
+    return () => {
+      console.log('Tournament waiting next match page unmounting...');
+      if (reconnectTimeout) {
+        window.clearTimeout(reconnectTimeout);
+      }
+      if (socket) {
+        socket.close();
+      }
+    };
   },
 });
 

--- a/frontend/src/pages/Tournament/WaitingNextMatch/index.ts
+++ b/frontend/src/pages/Tournament/WaitingNextMatch/index.ts
@@ -110,10 +110,10 @@ const WaitingNextMatchPage = new Page({
         }
         
         // 再接続を試行（5秒後）
-        if (reconnectTimeout) {
-          window.clearTimeout(reconnectTimeout);
-        }
-        reconnectTimeout = window.setTimeout(connectWebSocket, 5000);
+        // if (reconnectTimeout) {
+        //   window.clearTimeout(reconnectTimeout);
+        // }
+        // reconnectTimeout = window.setTimeout(connectWebSocket, 5000);
       };
     };
     

--- a/frontend/src/pages/Tournament/WaitingNextMatch/style.css
+++ b/frontend/src/pages/Tournament/WaitingNextMatch/style.css
@@ -1,52 +1,141 @@
 /* frontend/src/pages/Tournament/WaitingNextMatch/style.css */
-.container {
-  padding-top: 2rem;
-}
-
-.card {
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  transition: 0.3s;
-  margin-bottom: 2rem;
-}
-
-.card:hover {
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
-}
-
-.card-header {
-  background-color: #f8f9fa;
-  border-bottom: 1px solid #e3e6f0;
-}
-
-.card-header h2 {
-  margin-bottom: 0;
-  font-weight: 500;
-  color: #333;
-}
-
-.card-body {
+.waiting-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 80vh;
   padding: 2rem;
 }
 
-.btn-primary {
-  background-color: #4e73df;
-  border-color: #4e73df;
-  padding: 0.5rem 1.5rem;
-}
-
-.btn-primary:hover {
-  background-color: #2e59d9;
-  border-color: #2653d4;
-}
-
-.text-center {
+.waiting-box {
+  background-color: rgba(0, 0, 0, 0.7);
+  border-radius: 10px;
+  box-shadow: 0 0 20px rgba(0, 212, 255, 0.3);
+  padding: 2rem;
+  width: 100%;
+  max-width: 600px;
   text-align: center;
+  color: #fff;
 }
 
-.d-flex {
+.waiting-title {
+  font-size: 2rem;
+  margin-bottom: 1.5rem;
+  color: #00d4ff;
+  text-shadow: 0 0 10px rgba(0, 212, 255, 0.5);
+}
+
+.status-section {
+  margin-bottom: 2rem;
+}
+
+.loading-spinner {
+  width: 50px;
+  height: 50px;
+  border: 5px solid rgba(0, 212, 255, 0.15);
+  border-top: 5px solid #00d4ff;
+  border-radius: 50%;
+  margin: 0 auto 1rem;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+#status-message {
+  font-size: 1.2rem;
+  margin-bottom: 0.5rem;
+}
+
+#player-status {
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.players-section {
+  margin-bottom: 2rem;
+}
+
+.players-section h3 {
+  margin-bottom: 1rem;
+  color: #00d4ff;
+}
+
+.players-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.player-item {
   display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.8rem 1rem;
+  margin-bottom: 0.5rem;
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 5px;
+  transition: background-color 0.3s;
 }
 
-.justify-content-center {
-  justify-content: center;
+.player-item:hover {
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.player-item.you {
+  border-left: 3px solid #00d4ff;
+}
+
+.player-tag {
+  background-color: #00d4ff;
+  color: #000;
+  padding: 0.2rem 0.5rem;
+  border-radius: 3px;
+  font-size: 0.75rem;
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
+.player-name {
+  flex-grow: 1;
+  text-align: left;
+  margin-left: 0.5rem;
+}
+
+.status-tag {
+  padding: 0.3rem 0.6rem;
+  border-radius: 3px;
+  font-size: 0.8rem;
+}
+
+.status-tag.ready {
+  background-color: #1cc88a;
+  color: white;
+}
+
+.status-tag.waiting {
+  background-color: #f6c23e;
+  color: #333;
+}
+
+.actions-section {
+  margin-top: 2rem;
+}
+
+.cancel-button {
+  padding: 0.8rem 1.5rem;
+  background: linear-gradient(45deg, #ff416c, #ff4b2b);
+  color: white;
+  border: none;
+  border-radius: 5px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.3s;
+}
+
+.cancel-button:hover {
+  transform: scale(1.05);
+  box-shadow: 0 0 15px rgba(255, 75, 43, 0.5);
 }


### PR DESCRIPTION
## 概要
トーナメント機能の完成まで

1. ウェイティング
2. 1回戦プレイ
3. 勝者は決勝待機画面へ
4. 決勝プレイ
5. 結果画面へ

## 変更点
トーナメント関連のウェブソケットクラス、フロントエンド

## テスト
既存機能に影響なし

- トーナメントを最後までプレイできる
- 途中切断はすべて敗北の判定になる
- データベースに正しく途中経過も記録されている

## 関連Issue
- 関連Issue: #212 