### PR TITLE
FIX: シングルプレイの正しいスコア保存 #242

### DIFF
--- a/frontend/src/models/Game/repository.ts
+++ b/frontend/src/models/Game/repository.ts
@@ -24,7 +24,7 @@ export const createSinglePlayGame = async ({
     game_type: 'SINGLE',
     player1: currentUser.username,
     player2: null,
-    scorePlayer1: playerScore,
+    score_player1: playerScore,
     score_player2: cpuScore,
     winner: playerScore > cpuScore ? currentUser.username : null,
     ai_level: aiLevel,

--- a/frontend/src/pages/SinglePlay/Game/LocalGame.ts
+++ b/frontend/src/pages/SinglePlay/Game/LocalGame.ts
@@ -174,6 +174,7 @@ export default class LocalGame {
         `${this.scorePaddleOne} - ${this.scorePaddleTwo}`
       );
 
+      // TODO: scorePaddleOne, scorePaddleTwoの作成を修正する
       createSinglePlayGame({
         playerScore: this.scorePaddleOne,
         cpuScore: this.scorePaddleTwo,

--- a/frontend/src/pages/SinglePlay/Game/LocalGame.ts
+++ b/frontend/src/pages/SinglePlay/Game/LocalGame.ts
@@ -174,7 +174,6 @@ export default class LocalGame {
         `${this.scorePaddleOne} - ${this.scorePaddleTwo}`
       );
 
-      // TODO: scorePaddleOne, scorePaddleTwoの作成を修正する
       createSinglePlayGame({
         playerScore: this.scorePaddleOne,
         cpuScore: this.scorePaddleTwo,


### PR DESCRIPTION
## 概要
シングルプレイの結果が正しく保存されるように修正する

## 変更点
- frontend/src/pages/SinglePlay/Game/LocalGame.tsだけの予定

## 影響範囲
特になし

## テスト
シングルプレイをプレイし、結果が正しいスコアでDBに保存される

## 関連Issue
- 関連Issue: #242 