### PR TITLE
ADD: userモデルのレベルを上げられるように#262

### DIFF
--- a/api/pong/admin.py
+++ b/api/pong/admin.py
@@ -12,7 +12,6 @@ class CustomUserAdmin(UserAdmin):
         "email",
         "level",
         "avatar",
-        "experience",
         "is_staff",
         "is_superuser",
         "is_active",
@@ -24,7 +23,7 @@ class CustomUserAdmin(UserAdmin):
         (None, {"fields": ("username", "password")}),
         (
             "Personal info",
-            {"fields": ("display_name", "avatar", "email", "level", "experience")},
+            {"fields": ("display_name", "avatar", "email", "level")},
         ),
         (
             "Permissions",

--- a/api/pong/base_consumers.py
+++ b/api/pong/base_consumers.py
@@ -133,13 +133,13 @@ class BaseGameConsumer(AsyncWebsocketConsumer):
                     game_instance.status = "COMPLETED"
 
             game_instance.save()
-            
+
             # Update levels for both players when game ends
             player1 = User.objects.get(username=game.player1_name)
             player1.update_level()
-            
+
             # Also update player2's level if it's not an AI opponent
-            if game.player2_name and not hasattr(game, 'ai_level'):
+            if game.player2_name and not hasattr(game, "ai_level"):
                 player2 = User.objects.get(username=game.player2_name)
                 player2.update_level()
 

--- a/api/pong/base_consumers.py
+++ b/api/pong/base_consumers.py
@@ -133,6 +133,16 @@ class BaseGameConsumer(AsyncWebsocketConsumer):
                     game_instance.status = "COMPLETED"
 
             game_instance.save()
+            
+            # Update levels for both players when game ends
+            player1 = User.objects.get(username=game.player1_name)
+            player1.update_level()
+            
+            # Also update player2's level if it's not an AI opponent
+            if game.player2_name and not hasattr(game, 'ai_level'):
+                player2 = User.objects.get(username=game.player2_name)
+                player2.update_level()
+
         except Game.DoesNotExist:
             print(f"Game with id {game.db_game_id} not found")
         except Exception as e:

--- a/api/pong/fixtures/initial_data.json
+++ b/api/pong/fixtures/initial_data.json
@@ -7,7 +7,6 @@
       "email": "sample1@example.com",
       "display_name": "Sample User 1",
       "level": 1,
-      "experience": 0,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$d1SVqv6JNn2TJzcHrQlNNM$9KncMxadPq0mDXp14OF/xgQKdlYx9wQ0lDSk1WjVHxo="
@@ -21,7 +20,6 @@
       "email": "sample2@example.com",
       "display_name": "Sample User 2",
       "level": 2,
-      "experience": 100,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$Mh9ZxqtXGTgpy5WtGgyLRe$qgnJ8T9LuIF+PoGC5vA+0LpDStfJqx5GwtgSh3eBfxg="
@@ -35,7 +33,6 @@
       "email": "sample3@example.com",
       "display_name": "Sample User 3",
       "level": 3,
-      "experience": 200,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$2OHhBX0V5HPXJp9iJt5o9u$ocJdyW7lv3YxNYJppIzFqBLvOZz22vz9U/6FGCLeazw="
@@ -49,7 +46,6 @@
       "email": "sample4@example.com",
       "display_name": "Sample User 4",
       "level": 4,
-      "experience": 300,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$4mPN0uBMUn61H9mxA4lqxo$ZCnPpUkOteD8tynoWUvOvHDiy+i833cChRut6A2/3fo="
@@ -63,7 +59,6 @@
       "email": "sample5@example.com",
       "display_name": "Sample User 5",
       "level": 5,
-      "experience": 400,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$wfo2dFMu3QH5X1zGsdBPlK$1H1MMytNIhODInX/K9y40uN7Vyso/YslNv0XAGWXRhQ="
@@ -77,7 +72,6 @@
       "email": "sample6@example.com",
       "display_name": "Sample User 6",
       "level": 6,
-      "experience": 500,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$KnT3UqtbMfz5ETHpfQZJY2$8w6xolxoILIRkBwaiOsnPcZ/AdF3NRw74I3txJV4v4w="
@@ -91,7 +85,6 @@
       "email": "sample7@example.com",
       "display_name": "Sample User 7",
       "level": 7,
-      "experience": 600,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$zK0rCyfPrh8GnIHqADR5jK$JduM2lD9tePPVvNwEZHOFNB88K1kDQp+MHzIyoKsRq0="
@@ -105,7 +98,6 @@
       "email": "sample8@example.com",
       "display_name": "Sample User 8",
       "level": 8,
-      "experience": 700,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$Pgh45OC1Umrijzcep0sQgL$8up6nvCxHRbzkof5G0xaqHyNNZzfvKC5yx1IXDVKbuA="
@@ -119,7 +111,6 @@
       "email": "sample9@example.com",
       "display_name": "Sample User 9",
       "level": 9,
-      "experience": 800,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$Uuoe8xTRPSOUiOQZeEPRyG$4DlM4JzkP73iALX6oA1H5V6zOZ3PnV/1ABnbPCVivsM="
@@ -133,7 +124,6 @@
       "email": "sample10@example.com",
       "display_name": "Sample User 10",
       "level": 10,
-      "experience": 900,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$F76o8VRowp1bNYaqda7XjU$bXJyyOv96MR7ZfgHIzWuNl9dAR2kADKwO6hr9X7JLts="
@@ -147,7 +137,6 @@
       "email": "sample11@example.com",
       "display_name": "Sample User 11",
       "level": 10,
-      "experience": 900,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$K4nvyWY5NPgr7IaFbAfGbp$cJYOU0mHWUsRVpzORLXyOcpldlctU6L4lF+7fV/aomQ="
@@ -161,7 +150,6 @@
       "email": "sample12@example.com",
       "display_name": "Sample User 12",
       "level": 10,
-      "experience": 900,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$K4nvyWY5NPgr7IaFbAfGbp$cJYOU0mHWUsRVpzORLXyOcpldlctU6L4lF+7fV/aomQ="
@@ -175,7 +163,6 @@
       "email": "sample13@example.com",
       "display_name": "Sample User 13",
       "level": 10,
-      "experience": 900,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$K4nvyWY5NPgr7IaFbAfGbp$cJYOU0mHWUsRVpzORLXyOcpldlctU6L4lF+7fV/aomQ="
@@ -189,7 +176,6 @@
       "email": "sample14@example.com",
       "display_name": "Sample User 14",
       "level": 10,
-      "experience": 900,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$K4nvyWY5NPgr7IaFbAfGbp$cJYOU0mHWUsRVpzORLXyOcpldlctU6L4lF+7fV/aomQ="
@@ -203,7 +189,6 @@
       "email": "sample15@example.com",
       "display_name": "Sample User 15",
       "level": 10,
-      "experience": 900,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$K4nvyWY5NPgr7IaFbAfGbp$cJYOU0mHWUsRVpzORLXyOcpldlctU6L4lF+7fV/aomQ="
@@ -217,7 +202,6 @@
       "email": "sample16@example.com",
       "display_name": "Sample User 16",
       "level": 10,
-      "experience": 900,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$K4nvyWY5NPgr7IaFbAfGbp$cJYOU0mHWUsRVpzORLXyOcpldlctU6L4lF+7fV/aomQ="
@@ -231,7 +215,6 @@
       "email": "sample17@example.com",
       "display_name": "Sample User 17",
       "level": 10,
-      "experience": 900,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$K4nvyWY5NPgr7IaFbAfGbp$cJYOU0mHWUsRVpzORLXyOcpldlctU6L4lF+7fV/aomQ="
@@ -245,7 +228,6 @@
       "email": "sample18@example.com",
       "display_name": "Sample User 18",
       "level": 10,
-      "experience": 900,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$K4nvyWY5NPgr7IaFbAfGbp$cJYOU0mHWUsRVpzORLXyOcpldlctU6L4lF+7fV/aomQ="
@@ -259,7 +241,6 @@
       "email": "sample19@example.com",
       "display_name": "Sample User 19",
       "level": 10,
-      "experience": 900,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$K4nvyWY5NPgr7IaFbAfGbp$cJYOU0mHWUsRVpzORLXyOcpldlctU6L4lF+7fV/aomQ="
@@ -273,7 +254,6 @@
       "email": "sample20@example.com",
       "display_name": "Sample User 20",
       "level": 10,
-      "experience": 900,
       "is_staff": true,
       "is_superuser": true,
       "password": "pbkdf2_sha256$870000$K4nvyWY5NPgr7IaFbAfGbp$cJYOU0mHWUsRVpzORLXyOcpldlctU6L4lF+7fV/aomQ="

--- a/api/pong/migrations/0001_initial.py
+++ b/api/pong/migrations/0001_initial.py
@@ -109,7 +109,6 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("level", models.IntegerField(default=1)),
-                ("experience", models.IntegerField(default=0)),
                 ("language", models.CharField(default="en", max_length=10)),
                 ("is_online", models.BooleanField(default=False)),
                 ("last_activity", models.DateTimeField(blank=True, null=True)),

--- a/api/pong/models.py
+++ b/api/pong/models.py
@@ -9,7 +9,6 @@ class User(AbstractUser):
         upload_to="avatars/", null=True, blank=True, default="default_avatar.png"
     )
     level = models.IntegerField(default=1)
-    experience = models.IntegerField(default=0)
     language = models.CharField(max_length=10, default="en")
     is_online = models.BooleanField(default=False)
     last_activity = models.DateTimeField(null=True, blank=True)
@@ -69,6 +68,28 @@ class User(AbstractUser):
         )[:limit]
 
         return recent_games
+    
+    def calculate_level(self):
+        """
+        Calculate user level based on total games played.
+        Starting at level 1, player gains 1 level for every 3 games played.
+        """
+        total_games = self.total_games_played
+        new_level = 1 + (total_games // 3)
+        return new_level
+    
+    def update_level(self):
+        """
+        Update the player's level based on total games played.
+        Returns: (level_changed, old_level, new_level)
+        """
+        new_level = self.calculate_level()
+        if new_level > self.level:
+            old_level = self.level
+            self.level = new_level
+            self.save(update_fields=['level'])
+            return True, old_level, new_level
+        return False, self.level, self.level
 
 
 class Game(models.Model):

--- a/api/pong/models.py
+++ b/api/pong/models.py
@@ -68,7 +68,7 @@ class User(AbstractUser):
         )[:limit]
 
         return recent_games
-    
+
     def calculate_level(self):
         """
         Calculate user level based on total games played.
@@ -77,7 +77,7 @@ class User(AbstractUser):
         total_games = self.total_games_played
         new_level = 1 + (total_games // 3)
         return new_level
-    
+
     # NOTE: 初期化データで経験した試合数よりレベルが高いユーザは
     # 最初にレベルが上昇しないバグがあるように見えるが、これは仕様です.
     def update_level(self):
@@ -89,7 +89,7 @@ class User(AbstractUser):
         if new_level > self.level:
             old_level = self.level
             self.level = new_level
-            self.save(update_fields=['level'])
+            self.save(update_fields=["level"])
             return True, old_level, new_level
         return False, self.level, self.level
 

--- a/api/pong/models.py
+++ b/api/pong/models.py
@@ -78,6 +78,8 @@ class User(AbstractUser):
         new_level = 1 + (total_games // 3)
         return new_level
     
+    # NOTE: 初期化データで経験した試合数よりレベルが高いユーザは
+    # 最初にレベルが上昇しないバグがあるように見えるが、これは仕様です.
     def update_level(self):
         """
         Update the player's level based on total games played.

--- a/api/pong/serializers.py
+++ b/api/pong/serializers.py
@@ -50,7 +50,6 @@ class UserSerializer(serializers.ModelSerializer):
             "password",
             "avatar",
             "level",
-            "experience",
             "language",
             "is_online",
             "friends",
@@ -80,7 +79,6 @@ class UserSerializer(serializers.ModelSerializer):
             display_name=validated_data["display_name"],
             avatar=validated_data.get("avatar", ""),
             level=validated_data.get("level", 1),
-            experience=validated_data.get("experience", 0),
             language=validated_data.get("language", "en"),
             is_online=validated_data.get("is_online", False),
         )

--- a/api/pong/tests/test_model.py
+++ b/api/pong/tests/test_model.py
@@ -13,7 +13,6 @@ class UserModelTests(TestCase):
             password="testpass123",
             display_name="Test User",
             level=2,
-            experience=100,
         )
         self.assertIsNotNone(
             user.id, "User should be created successfully and assigned an ID"
@@ -21,7 +20,6 @@ class UserModelTests(TestCase):
         self.assertEqual(user.username, "testuser")
         self.assertEqual(user.display_name, "Test User")
         self.assertEqual(user.level, 2)
-        self.assertEqual(user.experience, 100)
 
     def test_str_representation(self):
         """

--- a/api/pong/views.py
+++ b/api/pong/views.py
@@ -268,6 +268,10 @@ class GameListCreateView(generics.ListCreateAPIView):
         serializer.is_valid(raise_exception=True)
         game = serializer.save()
 
+        # Update player level for completed games
+        if game.status == "COMPLETED":
+            game.player1.update_level()
+
         return Response(
             {
                 "game": GameSerializer(

--- a/frontend/src/libs/Auth/currnetUser.ts
+++ b/frontend/src/libs/Auth/currnetUser.ts
@@ -39,7 +39,7 @@ export const checkAuthentication = async (): Promise<ICurrentUser> => {
       level: 1,
       language: 'en',
       is_online: false,
-      total_matches: 0, 
+      total_matches: 0,
       wins: 0,
       losses: 0,
       tournament_wins: 0,

--- a/frontend/src/libs/Auth/currnetUser.ts
+++ b/frontend/src/libs/Auth/currnetUser.ts
@@ -40,6 +40,10 @@ export const checkAuthentication = async (): Promise<ICurrentUser> => {
       experience: 0,
       language: 'en',
       is_online: false,
+      total_matches: 0, 
+      wins: 0,
+      losses: 0,
+      tournament_wins: 0,
     };
   }
 };

--- a/frontend/src/libs/Auth/currnetUser.ts
+++ b/frontend/src/libs/Auth/currnetUser.ts
@@ -37,7 +37,6 @@ export const checkAuthentication = async (): Promise<ICurrentUser> => {
       display_name: '',
       avatar: '',
       level: 1,
-      experience: 0,
       language: 'en',
       is_online: false,
       total_matches: 0, 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -36,7 +36,6 @@
   "backToHome": "Back to Home",
   "userProfile": "User Profile",
   "myCard": "My Card",
-  "currentExperience": "Current Experience",
   "level": "Level",
   "tapToShowBack": "Tap or click to show the back",
   "tapToShowFront": "Tap or click to show the front",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -36,7 +36,6 @@
   "backToHome": "Retour à l'accueil",
   "userProfile": "Profil utilisateur",
   "myCard": "Ma carte",
-  "currentExperience": "Expérience actuelle",
   "level": "Niveau",
   "tapToShowBack": "Appuyez ou cliquez pour montrer le dos",
   "tapToShowFront": "Appuyez ou cliquez pour montrer le devant",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -36,7 +36,6 @@
   "backToHome": "ホームに戻る",
   "userProfile": "ユーザープロフィール",
   "myCard": "マイカード",
-  "currentExperience": "現在の経験値",
   "level": "レベル",
   "tapToShowBack": "裏面を表示するにはタップまたはクリック",
   "tapToShowFront": "表面を表示するにはタップまたはクリック",

--- a/frontend/src/models/User/type.ts
+++ b/frontend/src/models/User/type.ts
@@ -7,7 +7,6 @@ export interface IUser {
   display_name: string;
   avatar: string;
   level: number;
-  experience: number;
   language: keyof typeof languageNames;
   is_online: boolean;
   total_matches: number; // 総試合数

--- a/frontend/src/models/interface.ts
+++ b/frontend/src/models/interface.ts
@@ -12,9 +12,3 @@ export interface IRankingUser {
   username: string;
   level: number;
 }
-
-// FIXME: RM???
-export interface IBlockchainScore {
-  txHash: string;
-  score: number;
-}

--- a/frontend/src/pages/SinglePlay/Game/index.ts
+++ b/frontend/src/pages/SinglePlay/Game/index.ts
@@ -60,12 +60,11 @@ export function showGameOverOverlay(message: string, finalScore: string) {
   const exitBtn = document.getElementById('exitBtn');
   const scoreDisplay = document.getElementById('scoreDisplay');
 
-  if (overlay && endMessage && finalScoreElem && retryBtn && exitBtn && scoreDisplay) {
+  if (overlay && endMessage && finalElem && retryBtn && exitBtn && scoreDisplay) {
     endMessage.textContent = message; // "GAME OVER" または "YOU WIN!"
-    finalScoreElem.textContent = `Score: ${finalScore}`;
+    finalElem.textContent = `Score: ${finalScore}`;
 
     scoreDisplay.classList.add('hidden');
-    // 非表示クラスを削除し、opacity 0 から1にフェードイン
     overlay.classList.remove('hidden');
     gsap.fromTo(overlay, { opacity: 0 }, { opacity: 1, duration: 1 });
     retryBtn.addEventListener('click', () => {

--- a/frontend/src/pages/SinglePlay/Select/index.ts
+++ b/frontend/src/pages/SinglePlay/Select/index.ts
@@ -43,8 +43,8 @@ const SinglePlaySelectPage = new Page({
       i18next.changeLanguage(userData.language, updatePageContent);
     }
 
-    // Oniモードの表示条件をチェック（例: userData.points >= 1000）
-    const oniSelectable = userData.points >= 1000;
+    // Oniモードの表示条件をチェック
+    const oniSelectable = userData.level >= 10;
 
     const secretLevelCard = document.querySelector('.level-card.secret-level');
     if (secretLevelCard instanceof HTMLElement) {

--- a/frontend/src/pages/SinglePlay/Select/index.ts
+++ b/frontend/src/pages/SinglePlay/Select/index.ts
@@ -44,6 +44,7 @@ const SinglePlaySelectPage = new Page({
     }
 
     // Oniモードの表示条件をチェック
+    // FIXME: レベル制限を非ハードコーディングにしたい
     const oniSelectable = userData.level >= 10;
 
     const secretLevelCard = document.querySelector('.level-card.secret-level');


### PR DESCRIPTION
## 概要
userモデルにあるレベルフィールドにアップデート機能を追加

## 変更点
- 経験値フィールドを削除しました（単純化のため）

## 影響範囲
- ONIの表示判定を10レベル以上としました。

## テスト

- 試合をこなして3試合ごとにレベルがあがる(内部ロジックを今後アップデート可能である)
- 10レベル未満はONIが選択できない
- 10レベル以上はONIが選択できる

## 関連Issue
- 関連Issue: #262 
