### PR TITLE
FIX: トーナメントのウェイティング画面でユーザのアイコンが正しく取得できていない #238

### DIFF
--- a/frontend/src/pages/Tournament/Waiting/index.ts
+++ b/frontend/src/pages/Tournament/Waiting/index.ts
@@ -69,7 +69,6 @@ const WaitingPage = new Page({
 
           // プレイヤー情報を構築
           playerItem.innerHTML = `
-            <img src="${API_URL}/media/default_avatar.png" alt="${player.username}" class="player-avatar">
             <div class="player-name">${player.display_name || player.username}</div>
             <div class="ready-status ready-yes">Ready</div>
           `;

--- a/frontend/src/pages/Tournament/Waiting/style.css
+++ b/frontend/src/pages/Tournament/Waiting/style.css
@@ -47,14 +47,6 @@
   padding: 8px 12px;
 }
 
-.player-avatar {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  margin-right: 12px;
-  object-fit: cover;
-}
-
 .player-name {
   font-weight: 500;
   margin-bottom: 0;


### PR DESCRIPTION
必須ではないためそもそもアイコンを削除
fetchUserAvatar関数のリファクタが必要になりそうだったが、必須事項ではないのでかんたんに解決した