### PR TITLE
ADD: 多言語対応下準備(single, multi, tournament) #280

### DIFF
--- a/frontend/src/pages/MultiPlay/Game/index.ts
+++ b/frontend/src/pages/MultiPlay/Game/index.ts
@@ -1,9 +1,16 @@
 // frontend/src/pages/MultiPlay/Game/index.ts
 import { WS_URL } from '@/config/config';
+import i18next from '@/config/i18n';
 import { Page } from '@/core/Page';
 import AuthLayout from '@/layouts/AuthLayout';
 import { IGameConfig } from '@/models/Game/type';
 import { MultiplayerGameManager } from '@/models/MultiPlay/MultiplayerGameManager';
+import { setUserLanguage } from '@/utils/language';
+import { updateText } from '@/utils/updateElements';
+
+const updatePageContent = (): void => {
+  updateText('title', i18next.t('singlePlay.title'));
+};
 
 const GamePage = new Page({
   name: 'MultiPlay/Game',
@@ -11,6 +18,7 @@ const GamePage = new Page({
     layout: AuthLayout,
   },
   mounted: async ({ pg, user }) => {
+    setUserLanguage(user.language, updatePageContent);
     console.log('Game page mounting...');
 
     // URLパラメータの取得と検証

--- a/frontend/src/pages/MultiPlay/Game/index.ts
+++ b/frontend/src/pages/MultiPlay/Game/index.ts
@@ -9,7 +9,17 @@ import { setUserLanguage } from '@/utils/language';
 import { updateText } from '@/utils/updateElements';
 
 const updatePageContent = (): void => {
-  updateText('title', i18next.t('singlePlay.title'));
+  // ブラウザタブに表示されるタイトルを更新
+  updateText('title', i18next.t('multiplay.game.pageTitle'));
+
+  // ゲーム終了時の見出し (例："Game Over") を更新
+  updateText('#game-over h1', i18next.t('multiplay.game.gameOverTitle'));
+
+  // 勝者情報の文言 (例："Winner:") を更新
+  updateText('#game-over p', i18next.t('multiplay.game.winnerText'));
+
+  // 「Exit to Menu」ボタンのテキストを更新
+  updateText('#exit-btn', i18next.t('multiplay.game.exitButton'));
 };
 
 const GamePage = new Page({

--- a/frontend/src/pages/MultiPlay/Waiting/index.ts
+++ b/frontend/src/pages/MultiPlay/Waiting/index.ts
@@ -8,7 +8,17 @@ import { setUserLanguage } from '@/utils/language';
 import { updateText } from '@/utils/updateElements';
 
 const updatePageContent = (): void => {
-  updateText('title', i18next.t('singlePlay.title'));
+  // ブラウザタブのタイトルを更新
+  updateText('title', i18next.t('multiplay.waiting.pageTitle'));
+
+  // 待機画面の見出し（例："Finding a Match"）を更新
+  updateText('.waiting-container h1', i18next.t('multiplay.waiting.heading'));
+
+  // 接続状況のテキストを更新（例："Connecting..."）
+  updateText('#connection-status', i18next.t('multiplay.waiting.connectionStatus'));
+
+  // キャンセルボタンのテキストを更新（例："Cancel"）
+  updateText('#cancel-button', i18next.t('multiplay.waiting.cancelButton'));
 };
 
 /**

--- a/frontend/src/pages/MultiPlay/Waiting/index.ts
+++ b/frontend/src/pages/MultiPlay/Waiting/index.ts
@@ -1,8 +1,15 @@
 // frontend/src/pages/MultiPlay/Waiting/index.ts
 import { WS_URL } from '@/config/config';
+import i18next from '@/config/i18n';
 import { Page } from '@/core/Page';
 import AuthLayout from '@/layouts/AuthLayout';
 import { ICurrentUser } from '@/libs/Auth/currnetUser';
+import { setUserLanguage } from '@/utils/language';
+import { updateText } from '@/utils/updateElements';
+
+const updatePageContent = (): void => {
+  updateText('title', i18next.t('singlePlay.title'));
+};
 
 /**
  * DOM要素の取得
@@ -122,6 +129,7 @@ const WaitingPage = new Page({
     html: '/src/pages/MultiPlay/Waiting/index.html',
   },
   mounted: async ({ pg, user }) => {
+    setUserLanguage(user.language, updatePageContent);
     console.log('Waiting page mounting...');
     let socket: WebSocket | null = null;
     const { statusElement, cancelButton } = getDomElements();

--- a/frontend/src/pages/MultiPlay/index.ts
+++ b/frontend/src/pages/MultiPlay/index.ts
@@ -6,7 +6,14 @@ import { setUserLanguage } from '@/utils/language';
 import { updateText } from '@/utils/updateElements';
 
 const updatePageContent = (): void => {
-  updateText('title', i18next.t('singlePlay.title'));
+  // ブラウザタブのタイトルを更新
+  updateText('title', i18next.t('multiplay.pageTitle'));
+
+  // メイン見出しを更新（例："Multiplayer Mode"）
+  updateText('h1', i18next.t('multiplay.heading'));
+
+  // 「Find Match」ボタンのテキストを更新
+  updateText('#start-matchmaking', i18next.t('multiplay.startMatchmaking'));
 };
 
 const MultiPlayPage = new Page({

--- a/frontend/src/pages/MultiPlay/index.ts
+++ b/frontend/src/pages/MultiPlay/index.ts
@@ -1,11 +1,19 @@
 // frontend/src/pages/MultiPlay/index.ts
+import i18next from '@/config/i18n';
 import { Page } from '@/core/Page';
 import AuthLayout from '@/layouts/AuthLayout';
+import { setUserLanguage } from '@/utils/language';
+import { updateText } from '@/utils/updateElements';
+
+const updatePageContent = (): void => {
+  updateText('title', i18next.t('singlePlay.title'));
+};
 
 const MultiPlayPage = new Page({
   name: 'MultiPlay',
   config: { layout: AuthLayout },
-  mounted: async ({ pg }: { pg: Page }): Promise<void> => {
+  mounted: async ({ pg, user }) => {
+    setUserLanguage(user.language, updatePageContent);
     document.getElementById('start-matchmaking')?.addEventListener('click', () => {
       window.location.href = '/multiplay/waiting';
     });

--- a/frontend/src/pages/SinglePlay/Game/index.ts
+++ b/frontend/src/pages/SinglePlay/Game/index.ts
@@ -1,10 +1,31 @@
-import gsap from 'gsap';
+import i18next from '@/config/i18n';
 import { Page } from '@/core/Page';
-import Experience from './Experience';
-import { createParticleCustomizationPanel } from './CustomParticle';
 import AuthLayout from '@/layouts/AuthLayout';
+import { setUserLanguage } from '@/utils/language';
+import { updateText } from '@/utils/updateElements';
+import gsap from 'gsap';
+import { createParticleCustomizationPanel } from './CustomParticle';
+import Experience from './Experience';
 
 let running = true; // ゲームの状態管理
+
+const updatePageContent = (): void => {
+  updateText('title', i18next.t('singlePlay.title'));
+
+  // ポーズメニューのテキスト更新
+  updateText('#pauseOverlay h1', i18next.t('pauseMenu.title')); // 例: "Game Paused"
+  updateText('#resumeBtn', i18next.t('pauseMenu.resume')); // 例: "Resume"
+  updateText('#pauseRetryBtn', i18next.t('pauseMenu.retry')); // 例: "Retry"
+  updateText('#pauseExitBtn', i18next.t('pauseMenu.exit')); // 例: "Exit"
+
+  // ゲーム開始オーバーレイのテキスト更新
+  updateText('#gameStartOverlay h1', i18next.t('gameStart.title')); // 例: "Game Start"
+
+  // ゲームオーバーオーバーレイのテキスト更新
+  updateText('#endMessage', i18next.t('gameOver.title')); // 例: "Game Over" または "You Win!"
+  updateText('#gameOverRetryBtn', i18next.t('gameOver.retry')); // 例: "Retry"
+  updateText('#gameOverExitBtn', i18next.t('gameOver.exit')); // 例: "Exit"
+};
 
 // Pause メニューのセットアップ関数
 export function setupPauseMenu() {
@@ -86,6 +107,7 @@ const SinglePlayPage = new Page({
   },
 
   mounted: async ({ user }) => {
+    setUserLanguage(user.language, updatePageContent);
     // ヘッダーと背景を非表示にする
     const header = document.querySelector('.header');
     const background = document.getElementById('background');

--- a/frontend/src/pages/Tournament/Game/index.ts
+++ b/frontend/src/pages/Tournament/Game/index.ts
@@ -10,7 +10,23 @@ import { setUserLanguage } from '@/utils/language';
 import { updateText } from '@/utils/updateElements';
 
 const updatePageContent = (): void => {
-  updateText('title', i18next.t('singlePlay.title'));
+  // ブラウザタブのタイトルを更新
+  updateText('title', i18next.t('tournament.game.pageTitle'));
+
+  // ラウンド情報の表示を更新
+  updateText('#round-info', i18next.t('tournament.game.roundInfo'));
+
+  // ゲームオーバー時の見出し（例："Game Over"）を更新
+  updateText('#game-over h1', i18next.t('tournament.game.gameOverTitle'));
+
+  // 勝者情報の文言（例："Winner:"）を更新
+  updateText('#game-over p', i18next.t('tournament.game.winnerText'));
+
+  // 「Exit to Tournament」ボタンのテキストを更新
+  updateText('#exit-btn', i18next.t('tournament.game.exitButton'));
+
+  // 次試合待機情報のテキストを更新
+  updateText('#next-info p', i18next.t('tournament.game.waitingNextInfo'));
 };
 
 const GamePage = new Page({

--- a/frontend/src/pages/Tournament/Game/index.ts
+++ b/frontend/src/pages/Tournament/Game/index.ts
@@ -1,10 +1,17 @@
 // frontend/src/pages/Tournament/Game/index.ts
 import { WS_URL } from '@/config/config';
+import i18next from '@/config/i18n';
+import { logger } from '@/core/Logger';
 import { Page } from '@/core/Page';
 import AuthLayout from '@/layouts/AuthLayout';
-import { logger } from '@/core/Logger';
 import { IGameConfig } from '@/models/Game/type';
 import { TournamentGameManager } from '@/models/Tournament/TournamentGameManager';
+import { setUserLanguage } from '@/utils/language';
+import { updateText } from '@/utils/updateElements';
+
+const updatePageContent = (): void => {
+  updateText('title', i18next.t('singlePlay.title'));
+};
 
 const GamePage = new Page({
   name: 'Tournament/Game',
@@ -13,6 +20,7 @@ const GamePage = new Page({
     html: '/src/pages/Tournament/Game/index.html',
   },
   mounted: async ({ pg, user }) => {
+    setUserLanguage(user.language, updatePageContent);
     logger.info('Tournament Game page mounting...');
 
     // URLパラメータの取得と検証

--- a/frontend/src/pages/Tournament/Waiting/index.ts
+++ b/frontend/src/pages/Tournament/Waiting/index.ts
@@ -8,7 +8,20 @@ import { setUserLanguage } from '@/utils/language';
 import { updateText } from '@/utils/updateElements';
 
 const updatePageContent = (): void => {
-  updateText('title', i18next.t('singlePlay.title'));
+  // ブラウザタブに表示されるページタイトルを更新
+  updateText('title', i18next.t('tournament.waiting.pageTitle'));
+
+  // カードヘッダーの見出し（待機室のタイトル）を更新
+  updateText('.card-header h2', i18next.t('tournament.waiting.roomTitle'));
+
+  // 接続状況のメッセージを更新
+  updateText('#connection-status', i18next.t('tournament.waiting.connectionStatus'));
+
+  // 参加者リストの見出しを更新
+  updateText('.players-list h4', i18next.t('tournament.waiting.participantsHeader'));
+
+  // 離脱ボタンのテキストを更新
+  updateText('#leave-button', i18next.t('tournament.waiting.leaveButton'));
 };
 
 const WaitingPage = new Page({

--- a/frontend/src/pages/Tournament/Waiting/index.ts
+++ b/frontend/src/pages/Tournament/Waiting/index.ts
@@ -1,9 +1,15 @@
 // frontend/src/pages/Tournament/Waiting/index.ts
 import { WS_URL } from '@/config/config';
-import { Page } from '@/core/Page';
+import i18next from '@/config/i18n';
 import { logger } from '@/core/Logger';
+import { Page } from '@/core/Page';
 import AuthLayout from '@/layouts/AuthLayout';
-import { API_URL } from '@/config/config';
+import { setUserLanguage } from '@/utils/language';
+import { updateText } from '@/utils/updateElements';
+
+const updatePageContent = (): void => {
+  updateText('title', i18next.t('singlePlay.title'));
+};
 
 const WaitingPage = new Page({
   name: 'Tournament/Waiting',
@@ -12,6 +18,7 @@ const WaitingPage = new Page({
     html: '/src/pages/Tournament/Waiting/index.html',
   },
   mounted: async ({ pg, user }) => {
+    setUserLanguage(user.language, updatePageContent);
     logger.info('Tournament waiting page - initializing');
 
     // DOM要素の取得

--- a/frontend/src/pages/Tournament/WaitingNextMatch/index.ts
+++ b/frontend/src/pages/Tournament/WaitingNextMatch/index.ts
@@ -8,9 +8,21 @@ import { setUserLanguage } from '@/utils/language';
 import { updateText } from '@/utils/updateElements';
 
 const updatePageContent = (): void => {
-  updateText('title', i18next.t('singlePlay.title'));
-};
+  // ページタイトルの更新
+  updateText('title', i18next.t('tournament.waitingNextMatch.pageTitle'));
 
+  // 待機画面の見出し更新
+  updateText('.waiting-title', i18next.t('tournament.waitingNextMatch.waitingTitle'));
+
+  // 初期ステータスメッセージの更新
+  updateText('#status-message', i18next.t('tournament.waitingNextMatch.statusWaiting'));
+
+  // プレイヤーリストのセクション見出し更新
+  updateText('.players-section h3', i18next.t('tournament.waitingNextMatch.finalistsHeading'));
+
+  // キャンセルボタンのテキスト更新
+  updateText('#cancel-button', i18next.t('tournament.waitingNextMatch.cancelButton'));
+};
 const WaitingNextMatchPage = new Page({
   name: 'Tournament/WaitingNextMatch',
   config: {

--- a/frontend/src/pages/Tournament/WaitingNextMatch/index.ts
+++ b/frontend/src/pages/Tournament/WaitingNextMatch/index.ts
@@ -1,8 +1,15 @@
 // frontend/src/pages/Tournament/WaitingNextMatch/index.ts
 import { WS_URL } from '@/config/config';
-import { Page } from '@/core/Page';
+import i18next from '@/config/i18n';
 import { logger } from '@/core/Logger';
+import { Page } from '@/core/Page';
 import AuthLayout from '@/layouts/AuthLayout';
+import { setUserLanguage } from '@/utils/language';
+import { updateText } from '@/utils/updateElements';
+
+const updatePageContent = (): void => {
+  updateText('title', i18next.t('singlePlay.title'));
+};
 
 const WaitingNextMatchPage = new Page({
   name: 'Tournament/WaitingNextMatch',
@@ -11,6 +18,7 @@ const WaitingNextMatchPage = new Page({
     html: '/src/pages/Tournament/WaitingNextMatch/index.html',
   },
   mounted: async ({ pg, user }) => {
+    setUserLanguage(user.language, updatePageContent);
     logger.info('Tournament waiting next match page mounting...');
 
     // URLパラメーターの取得

--- a/frontend/src/pages/Tournament/index.html
+++ b/frontend/src/pages/Tournament/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Friend Management</title>
+    <title>Tournament</title>
     <link
       href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500&display=swap"
       rel="stylesheet"

--- a/frontend/src/pages/Tournament/index.ts
+++ b/frontend/src/pages/Tournament/index.ts
@@ -1,5 +1,12 @@
+import i18next from '@/config/i18n';
 import { Page } from '@/core/Page';
 import AuthLayout from '@/layouts/AuthLayout';
+import { setUserLanguage } from '@/utils/language';
+import { updateText } from '@/utils/updateElements';
+
+const updatePageContent = (): void => {
+  updateText('title', i18next.t('singlePlay.title'));
+};
 
 const TournamentPage = new Page({
   name: 'Tournament',
@@ -7,7 +14,8 @@ const TournamentPage = new Page({
     layout: AuthLayout,
     html: '/src/pages/Tournament/index.html',
   },
-  mounted: async ({ pg }: { pg: Page }): Promise<void> => {
+  mounted: async ({ pg, user }) => {
+    setUserLanguage(user.language, updatePageContent);
     const startTournament = document.getElementById('start-tournament');
     if (startTournament) {
       startTournament.addEventListener('click', () => {

--- a/frontend/src/pages/Tournament/index.ts
+++ b/frontend/src/pages/Tournament/index.ts
@@ -5,7 +5,17 @@ import { setUserLanguage } from '@/utils/language';
 import { updateText } from '@/utils/updateElements';
 
 const updatePageContent = (): void => {
-  updateText('title', i18next.t('singlePlay.title'));
+  // ページタイトルの更新
+  updateText('title', i18next.t('tournament.title'));
+
+  // ページ内のタイトル（h1）の更新
+  updateText('.tournament-title', i18next.t('tournament.heading'));
+
+  // 説明文の更新
+  updateText('.tournament-info p', i18next.t('tournament.info'));
+
+  // トーナメント参加ボタンのテキスト更新
+  updateText('#start-tournament', i18next.t('tournament.startButton'));
 };
 
 const TournamentPage = new Page({


### PR DESCRIPTION
## 概要

多言語対応するための下準備
localesの中のjsonにあとは追記するだけ→別のPRで行う（今行うと他のPRとコンフリクトが起きる）

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- 関連Issue: #280 
- 関連Issue: #281 
- 関連Issue: #282 
- 関連Issue: #279 
